### PR TITLE
🎨 리스트 페이지 퍼블리싱

### DIFF
--- a/app/list/layout.tsx
+++ b/app/list/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from "react";
+
+export default function ListLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="mx-auto min-h-[calc(100vh-3.5rem)] overflow-y-auto bg-gray-50 lg:max-w-[70%]">
+      {children}
+    </div>
+  );
+}

--- a/app/list/page.tsx
+++ b/app/list/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Button from "@components/common/Button";
+import TabMenu from "@components/common/TabMenu";
+import { useState } from "react";
+import HeartImage from "@assets/img-head-class.svg";
+import Chip from "@components/common/Chip";
+
+const tabs = [
+  { label: "cloud", title: "구름링" },
+  { label: "tree", title: "나무링" },
+];
+
+export default function List() {
+  const [selectedIndex, setSelectedIndex] = useState<number>(0);
+  return (
+    <div className="flex flex-col px-4 pt-6 sm:px-6 sm:pt-8 lg:px-[102px]">
+      {/* 헤더 */}
+      <section className="justify-star mb-6 flex items-center gap-4 sm:mb-8">
+        <HeartImage className="w-18 h-18" />
+        <div>
+          <p className="text-sm font-medium">함께 할 사람이 없나요?</p>
+          <p className="mt-1 text-2xl font-semibold">
+            지금 모임에 참여해보세요
+          </p>
+        </div>
+      </section>
+
+      {/* 카테고리 달램핏 */}
+      <section className="mb-[14px] flex flex-wrap items-center justify-between">
+        <div>
+          <TabMenu
+            hasIcon
+            tabs={tabs}
+            selectedIndex={selectedIndex}
+            onSelect={setSelectedIndex}
+          />
+        </div>
+        <div className="flex items-center">
+          <Button text="모임 만들기" size="small" />
+        </div>
+      </section>
+
+      {/* 카테고리 달램핏 */}
+      <section className="flex justify-start gap-2">
+        <Chip label="전체" selected />
+        <Chip label="오피스 스트레칭" selected />
+        <Chip label="마인드폴니스" selected />
+      </section>
+
+      {/* 정렬필터 섹션 */}
+      <section />
+
+      {/* 카드섹션 */}
+      <section />
+    </div>
+  );
+}


### PR DESCRIPTION
## 📝작업 내용

리스트 페이지 퍼블리싱 하였습니다.
웹
<img width="1426" alt="image" src="https://github.com/user-attachments/assets/5b2e5596-76f6-4ed0-8c31-2b284d7d5cfe" />

모바일
<img width="498" alt="image" src="https://github.com/user-attachments/assets/2259463d-6678-4836-a1b7-665121836dcc" />

웹 모바일 테블릿에 맞는 반응형으로 구현했습니다.

세션 설명을 위한 주석을 넣었읍니다 이후에 제거하도록하겠습니다.

이후에 정렬 섹션과

카드리스트 섹션을 추가 예정입니다.
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 컴포넌트 분리에 대해서 조언주시면 감사하겠습니다..!
