### PR TITLE
 ✨ Gnb 공통 컴포넌트 로그인 분기 처리 및 드롭다운 메뉴 추가

### DIFF
--- a/components/common/Gnb.tsx
+++ b/components/common/Gnb.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useCookies } from "react-cookie";
 import { useState, useEffect } from "react";
 
@@ -18,27 +18,63 @@ const navLinks: NavLink[] = [
 ];
 
 function UserProfile() {
-  const [cookies] = useCookies(["token"]);
+  const [cookies, , removeCookie] = useCookies(["token"]);
   const [isMounted, setIsMounted] = useState(false);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const isLoggedIn = !!cookies.token;
   const profileImageSrc = "/image/img-profile-large-default.svg";
+  const router = useRouter();
 
   useEffect(() => {
     setIsMounted(true);
   }, []);
 
+  const handleLogout = () => {
+    removeCookie("token");
+    setIsDropdownOpen(false);
+    router.push("/");
+  };
+
   if (!isMounted) {
-    return <div className="h-10 w-10" />;
+    return null;
+    // TODO 데이터 로딩 표시를 추가할 지 말 지 데이터 확인 후 작업 예정
   }
 
   return isLoggedIn ? (
-    <Image
-      src={profileImageSrc}
-      alt="user profile image"
-      width={40}
-      height={40}
-      className="rounded-full"
-    />
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+        className="flex items-center justify-center focus:outline-none"
+      >
+        <Image
+          src={profileImageSrc}
+          alt="user profile image"
+          width={40}
+          height={40}
+          className="rounded-full"
+        />
+      </button>
+
+      {isDropdownOpen && (
+        <div className="absolute right-0 mt-1 flex w-fit flex-col gap-y-2 whitespace-nowrap rounded-md bg-white px-3 py-2 text-base font-medium text-gray-800 shadow-md lg:left-0">
+          <Link
+            href="/mypage"
+            className="block hover:bg-gray-100"
+            onClick={() => setIsDropdownOpen(false)}
+          >
+            마이페이지
+          </Link>
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="block w-full text-left hover:bg-gray-100"
+          >
+            로그아웃
+          </button>
+        </div>
+      )}
+    </div>
   ) : (
     <Link href="/signin">로그인</Link>
   );

--- a/components/common/Gnb.tsx
+++ b/components/common/Gnb.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
+import { useCookies } from "react-cookie";
+import { useState, useEffect } from "react";
 
 interface NavLink {
   href: string;
@@ -15,22 +17,30 @@ const navLinks: NavLink[] = [
   { href: "/review", label: "모든 리뷰" },
 ];
 
-function UserProfile({
-  isLoggedIn,
-  profileImageSrc,
-}: {
-  isLoggedIn: boolean;
-  profileImageSrc: string;
-}) {
+function UserProfile() {
+  const [cookies] = useCookies(["token"]);
+  const [isMounted, setIsMounted] = useState(false);
+  const isLoggedIn = !!cookies.token;
+  const profileImageSrc = "/image/img-profile-large-default.svg";
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted) {
+    return <div className="h-10 w-10" />;
+  }
+
   return isLoggedIn ? (
     <Image
       src={profileImageSrc}
       alt="user profile image"
       width={40}
       height={40}
+      className="rounded-full"
     />
   ) : (
-    <Link href="auth">로그인</Link>
+    <Link href="/signin">로그인</Link>
   );
 }
 
@@ -55,9 +65,6 @@ function NavLinks() {
 }
 
 export default function Gnb() {
-  const isLoggedIn = false;
-  const profileImageSrc = "/image/img-profile-large-default.svg";
-
   return (
     <nav className="flex h-14 flex-row items-center justify-between border-b-2 border-gray-300 bg-white px-6 text-sm font-medium sm:h-[3.75rem] sm:text-base lg:px-[15%]">
       <div className="flex">
@@ -66,7 +73,7 @@ export default function Gnb() {
         </Link>
         <NavLinks />
       </div>
-      <UserProfile isLoggedIn={isLoggedIn} profileImageSrc={profileImageSrc} />
+      <UserProfile />
     </nav>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

>

## 📝작업 내용
Gnb 공용 컴포넌트 작업했습니다.

기능 요구 사항 
<img width="593" alt="스크린샷 2025-02-10 오전 11 18 41" src="https://github.com/user-attachments/assets/95b2edf0-784e-4fc6-a8db-ba4e3e863626" />

- [x] 로고, 모임 찾기 클릭 시 모임 목록 페이지로 이동됩니다.
- [ ] 찜한 모임: 실제로 찜한 모임이 있다면 옆에 찜한 모임 개수를 알려주는 숫자 뱃지가 떠야 합니다. 추후 찜한 모임이 로컬 스토리지에 저장되는 작업이 확인되면 추가하겠습니다.
- [x] 계정 정보: 프로필 이미지가 표시 되며, 마이페이지 이동과 로그아웃이 가능합니다.

>기존에는 페이지 이동만 가능했으나, 이번 작업에서는 로그인 여부에 따른 분기 처리가 추가되었고, 사용자 프로필 이미지를 클릭 시 드롭다운 메뉴가 활성화되어 마이페이지 이동과 로그아웃 기능을 제공하게 되었습니다.


### 스크린샷 (선택)
<img width="1182" alt="스크린샷 2025-02-14 오후 2 43 36" src="https://github.com/user-attachments/assets/5d273a66-12d1-44c8-8dd5-cbf27dd5ae3b" />

## 💬리뷰 요구사항(선택)

> 지금은 일단 로그아웃 시 루트 ('/') 페이지로 이동하게 해놨습니다. 모임 찾기 페이지로 이동해야할 지, 어디로 이동하게 하는 게 좋을 지 의견주세요!