### PR TITLE
✨ dropdown 버튼 제거 버전으로 수정

### DIFF
--- a/components/common/DropDown.tsx
+++ b/components/common/DropDown.tsx
@@ -1,59 +1,58 @@
 /* eslint-disable react/require-default-props */
-import React, { useState } from "react";
+import React, { useEffect, useRef } from "react";
 import DropDownItems from "@components/common/DropDownItems";
-import ArrowIconDefault from "@assets/icon-arrow-default-down.svg";
-import ArrowIconInverse from "@assets/icon-arrow-inverse-down.svg";
-
-const fixedItemsList = [
-  "지역 전체",
-  "을지로 3가",
-  "홍대입구",
-  "강남역",
-  "건대입구",
-];
 
 interface DropDownProps {
+  items: string[];
   onSelect: (item: string) => void;
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  selectedItem?: string | null;
   variant?: "solid" | "outlined";
   textSize?: "large" | "small";
-  iconType?: "default" | "inverse";
 }
 
 function DropDown({
+  items,
   onSelect,
+  isOpen,
+  setIsOpen,
+  selectedItem = null,
   variant = "solid",
   textSize = "large",
-  iconType = "default",
 }: DropDownProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [selectedItem, setSelectedItem] = useState<string | null>(null);
-  const ArrowIcon =
-    iconType === "default" ? ArrowIconDefault : ArrowIconInverse;
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen, setIsOpen]);
   return (
-    <div className="relative">
-      <button
-        type="button"
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center text-gray-500 hover:text-gray-700"
-      >
-        <ArrowIcon className="h-5 w-5" />
-      </button>
-      {isOpen && (
+    <div className="relative" ref={dropdownRef}>
+      {isOpen && items.length > 0 && (
         <ul
           className={`absolute right-0 mt-1 ${
             variant === "solid" ? "w-[472px]" : "w-[110px]"
           } rounded-md border bg-white shadow-md`}
         >
-          {fixedItemsList.map((item) => (
+          {items.map((item) => (
             <DropDownItems
               key={item}
               item={item}
               isSelected={selectedItem === item}
               onSelect={(selected) => {
-                setSelectedItem(selected);
                 onSelect(selected);
-                setIsOpen(false);
+                if (isOpen) setIsOpen(false);
               }}
               textSize={textSize}
             />

--- a/components/common/DropDown.tsx
+++ b/components/common/DropDown.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/require-default-props */
 import React, { useState } from "react";
-import DropDownList from "@components/common/DropDownList";
+import DropDownItems from "@components/common/DropDownItems";
 import ArrowIconDefault from "@assets/icon-arrow-default-down.svg";
 import ArrowIconInverse from "@assets/icon-arrow-inverse-down.svg";
 
@@ -46,7 +46,7 @@ function DropDown({
           } rounded-md border bg-white shadow-md`}
         >
           {fixedItemsList.map((item) => (
-            <DropDownList
+            <DropDownItems
               key={item}
               item={item}
               isSelected={selectedItem === item}

--- a/components/common/DropDownItems.tsx
+++ b/components/common/DropDownItems.tsx
@@ -2,19 +2,19 @@
 import React from "react";
 import classNames from "classnames";
 
-interface DropDownListProps {
+interface DropDownItemsProps {
   item: string;
   isSelected: boolean;
   onSelect: (item: string) => void;
   textSize?: "large" | "small";
 }
 
-function DropDownList({
+function DropDownItems({
   item,
   isSelected = false,
   onSelect,
   textSize = "large",
-}: DropDownListProps) {
+}: DropDownItemsProps) {
   return (
     <li>
       <button
@@ -35,4 +35,4 @@ function DropDownList({
   );
 }
 
-export default DropDownList;
+export default DropDownItems;


### PR DESCRIPTION
## 📝작업 내용
기존의 dropdown 컴포넌트에서 변경사항 알려드립니다!

- [x] button 부분  제거
- [x] DropDownList -> DropDownItems 로 이름 변경
- [x] handleClickOutside 추가로 DropDown외부 클릭 시 닫히게 구현
- [x] 상위 컴포넌트에서 입력할 수 있도록 Items props 추가

-사용법 예시-
```
import React, { useState } from "react";
import DropDown from "@components/common/DropDown";

const ExampleItems = ["추가하고", "싶은", "아이템"];

function example() {
  const [isOpen, setIsOpen] = useState(false);
  const [selectedLocation, setSelectedLocation] = useState<string | null>(null);

  const handleSelect = (selected: string) => {
    setSelectedLocation(selected);
    setIsOpen(false);
  };

  return (
    <DropDown
      items={locations}
      onSelect={handleSelect}
      isOpen={isOpen}
      setIsOpen={setIsOpen}
      selectedItem={selectedLocation}
      variant="solid"
      textSize="large"
    />
  );
}

export default example;

```

DropDown 컴포넌트 위에 자유롭게 추가하셔서 드롭다운을 열고 닫을 컴포넌트 작성해주시면 됩니다!
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
사용해보시다가 문제되는 부분 있으면 말씀해주세요!