### PR TITLE
🐛 label text size 옵션 추가

### DIFF
--- a/components/common/Input.tsx
+++ b/components/common/Input.tsx
@@ -15,7 +15,17 @@ import EyeOn from "@assets/visibility_on.svg";
  */
 const Input = forwardRef<HTMLInputElement, InputProps>(
   (
-    { id, name, type, label, placeholder, isInvalid, onBlur, ...props },
+    {
+      id,
+      name,
+      type,
+      label,
+      placeholder,
+      isInvalid,
+      onBlur,
+      labelTextSize = "base",
+      ...props
+    },
     ref,
   ) => {
     const [isPasswordVisible, setIsPasswordVisible] = useState(false);
@@ -23,11 +33,15 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
     const togglePasswordVisibility = () => {
       setIsPasswordVisible((prev) => !prev);
     };
+
+    const textSize = labelTextSize === "sm" ? "text-sm" : "text-base";
+
     return (
       <div className="relative flex w-full flex-col items-start gap-2">
+        {/* TODO: auth페이지에서만 라벨 크기 text-sm으로 바꾸기 */}
         <label
           htmlFor={id}
-          className="w-full text-sm font-semibold text-gray-900"
+          className={`w-full ${textSize} font-semibold text-gray-900`}
         >
           {label}
         </label>

--- a/features/auth/components/SigninForm.tsx
+++ b/features/auth/components/SigninForm.tsx
@@ -71,6 +71,7 @@ export default function SigninForm() {
           id="email"
           type="email"
           label="아이디"
+          labelTextSize="sm"
           placeholder="아이디를 입력하세요"
           register={register}
           rules={{ required: "아이디를 입력해주세요", pattern: emailPattern }}
@@ -81,6 +82,7 @@ export default function SigninForm() {
           name="password"
           id="password"
           label="비밀번호"
+          labelTextSize="sm"
           type="password"
           placeholder="비밀번호를 입력하세요"
           register={register}

--- a/features/auth/components/SignupForm.tsx
+++ b/features/auth/components/SignupForm.tsx
@@ -66,6 +66,7 @@ export default function SignupForm() {
           id="name"
           type="text"
           label="이름"
+          labelTextSize="sm"
           placeholder="이름을 입력해주세요"
           register={register}
           rules={{ required: "이름을 입력해주세요" }}
@@ -77,6 +78,7 @@ export default function SignupForm() {
           id="email"
           type="email"
           label="아이디"
+          labelTextSize="sm"
           placeholder="아이디를 입력해주세요"
           register={register}
           rules={{ required: "아이디를 입력해주세요", pattern: emailPattern }}
@@ -89,6 +91,7 @@ export default function SignupForm() {
           id="companyName"
           type="text"
           label="소속"
+          labelTextSize="sm"
           placeholder="소속을 입력해주세요(학생,회사원 등)"
           register={register}
           rules={{ required: "소속을 입력해주세요" }}
@@ -99,6 +102,7 @@ export default function SignupForm() {
           name="password"
           id="password"
           label="비밀번호"
+          labelTextSize="sm"
           type="password"
           placeholder="비밀번호를 입력해주세요"
           register={register}
@@ -113,6 +117,7 @@ export default function SignupForm() {
           name="passwordConfirm"
           id="passwordConfirm"
           label="비밀번호 확인"
+          labelTextSize="sm"
           type="password"
           placeholder="비밀번호를 입력해주세요"
           register={register}

--- a/types/form.d.ts
+++ b/types/form.d.ts
@@ -18,6 +18,7 @@ export interface InputFormProps {
   name: keyof FormValues;
   type: string;
   label: string;
+  labelTextSize?: "sm" | "base";
   placeholder: string;
   register?: UseFormRegister<FormValues>;
   rules?: RegisterOptions;
@@ -28,5 +29,4 @@ export interface InputFormProps {
 export interface InputProps extends InputFormProps {
   name: string;
   isInvalid?: boolean;
-  labelTextSize?: "sm" | "base";
 }

--- a/types/form.d.ts
+++ b/types/form.d.ts
@@ -28,4 +28,5 @@ export interface InputFormProps {
 export interface InputProps extends InputFormProps {
   name: string;
   isInvalid?: boolean;
+  labelTextSize?: "sm" | "base";
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용
- [x] label text size 옵션 추가.

default는 text-base로 되어있습니다! auth페이지에서만 labelTextSize="sm"으로 사용하면 됩니다.
```
<InputForm
          name="email"
          id="email"
          type="email"
          label="아이디"
          // 이 부분 추가
          labelTextSize="sm"
          //
          placeholder="아이디를 입력하세요"
          register={register}
          rules={{ required: "아이디를 입력해주세요", pattern: emailPattern }}
          errors={errors}
          onBlur={() => trigger("email")}
        />
```
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

