### PR TITLE
🎨 Popup 컴포넌트 스타일링

### DIFF
--- a/components/common/Popup.tsx
+++ b/components/common/Popup.tsx
@@ -1,0 +1,33 @@
+import Image from "next/image";
+import Button from "@components/common/Button";
+
+interface PopupProps {
+  hasTwoButton?: boolean;
+  text: string;
+}
+
+export default function Popup({ hasTwoButton = false, text }: PopupProps) {
+  const alignItems = hasTwoButton ? "items-start" : "items-end";
+
+  return (
+    // gap-[0.625rem]
+    <div className="flex w-fit flex-col items-start rounded-lg bg-white p-6">
+      <div
+        className={`flex flex-col items-center gap-10 md:${alignItems} md:gap-6`}
+      >
+        <div className="flex flex-col items-end gap-6">
+          <Image src="/image/X.svg" alt="close button" width={24} height={24} />
+          <div className="w-[15.75rem] text-center text-base font-medium text-gray-900 md:w-[25.125rem]">
+            {text}
+          </div>
+        </div>
+        <div className="flex items-start gap-2">
+          {hasTwoButton && (
+            <Button text="취소" size="small" variant="outlined" />
+          )}
+          <Button text="확인" size="small" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/public/image/X.svg
+++ b/public/image/X.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 5L19.5 19.5" stroke="#111827" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M19.5 5L5 19.5" stroke="#111827" stroke-width="1.8" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용
- [x] Popup 컴포넌트 스타일링

### 스크린샷 (선택)
모바일
![캡처](https://github.com/user-attachments/assets/5b1b439d-1fc0-4b0f-8d86-a3a890534b27)

태블릿/pc
![캡처2](https://github.com/user-attachments/assets/f4e8d361-e5d2-4eda-a853-129aa11c976c)


## 💬리뷰 요구사항(선택)
컴포넌트 이름을 피그마에 있는 대로 Popup이라고 지었는데 생각해보니 해당 컴포넌트가 팝업의 역할과는 맞지 않는 것 같아 AlertModal으로 변경할 예정입니다..