### PR TITLE
✨ 정렬필터 드롭다운 추가

### DIFF
--- a/app/(layout_dafault)/list/page.tsx
+++ b/app/(layout_dafault)/list/page.tsx
@@ -18,11 +18,19 @@ export default function List() {
   //   undefined,
   // );
 
+  // const [selectedSort, setSelectedSort] = useState<string>("정렬");
+
   // 날짜가 변경될 때 API 요청을 보낼 수 있도록 상태 업데이트
   const handleDateChange = (date: string | undefined) => {
     // API 요청을 보낼 때 selectedDate를 활용
     console.log("API 요청: 필터링할 날짜 =", date || "전체");
   };
+
+  // 정렬 부분 사용 예정 (에러로 주석처리)
+  // const handleSortChange = (sortValue: string) => {
+  //   setSelectedSort(sortValue);
+  //   console.log("API 요청: 정렬 기준 =", sortValue);
+  // };
 
   return (
     <div className="flex w-full flex-col pt-6 md:pt-8">
@@ -68,7 +76,7 @@ export default function List() {
 
           <DateFilter onDateSelect={handleDateChange} />
         </div>
-        <SortFilter label="마감임박" />
+        <SortFilter variant="list" />
       </section>
     </div>
   );

--- a/components/common/DropDown.tsx
+++ b/components/common/DropDown.tsx
@@ -42,7 +42,7 @@ function DropDown({
       {isOpen && items.length > 0 && (
         <ul
           className={`absolute right-0 mt-1 ${
-            variant === "solid" ? "w-[472px]" : "w-[110px]"
+            variant === "solid" ? "w-[472px]" : "w-[120px]"
           } rounded-md border bg-white shadow-md`}
         >
           {items.map((item) => (

--- a/components/common/SortFilter.tsx
+++ b/components/common/SortFilter.tsx
@@ -1,21 +1,59 @@
 import SortDefault from "@assets/icon-sort-default.svg";
+import SortInverse from "@assets/icon-sort-inverse.svg";
+import { useState } from "react";
+import DropDown from "@components/common/DropDown";
 
 interface SortFilterProps {
-  label: string;
-  onClick?: () => void;
+  onSortChange?: (selected: string) => void;
+  variant?: "list" | "review";
 }
 
-export default function SortFilter({ label, onClick }: SortFilterProps) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-label={label}
-      className="inline-flex h-9 w-10 items-center justify-start gap-1 rounded-lg border-2 border-gray-100 bg-white p-[0.375rem] text-sm font-medium text-gray-900 transition md:h-10 md:w-[7.5rem] md:px-3 md:py-2"
-    >
-      <SortDefault />
+export default function SortFilter({
+  onSortChange,
+  variant = "review",
+}: SortFilterProps) {
+  const itemsMap = {
+    list: ["정렬", "최신순", "마감 임박", "참여 인원순"],
+    review: ["정렬", "최신순", "평점 높은순", "참여 인원순"],
+  };
 
-      <div className="hidden md:block">{label}</div>
-    </button>
+  const items = itemsMap[variant];
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedLocation, setSelectedLocation] = useState<string | null>(
+    items[0],
+  );
+  const handleSelect = (selected: string) => {
+    setSelectedLocation(selected);
+    setIsOpen(false);
+    if (onSortChange) {
+      onSortChange(selected);
+    }
+  };
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-label="정렬 필터"
+        className={`${selectedLocation === "정렬" ? "border-gray-100 bg-white text-gray-900" : "border-black bg-gray-900 text-white"} inline-flex h-9 w-10 items-center justify-between gap-1 rounded-lg border-2 p-[0.375rem] text-sm font-medium transition md:h-10 md:w-fit md:min-w-[7.5rem] md:px-3 md:py-2`}
+      >
+        {selectedLocation === "정렬" ? <SortDefault /> : <SortInverse />}
+
+        <div className="hidden whitespace-nowrap md:block">
+          {selectedLocation}
+        </div>
+      </button>
+      <DropDown
+        items={items}
+        onSelect={handleSelect}
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        selectedItem={selectedLocation}
+        variant="outlined"
+        textSize="small"
+      />
+    </div>
   );
 }

--- a/features/review/components/FilterBar.tsx
+++ b/features/review/components/FilterBar.tsx
@@ -10,7 +10,7 @@ export default function FilterBar() {
           <DateFilter />
           <DateFilter />
         </div>
-        <SortFilter label="최신 순" />
+        <SortFilter variant="review" />
       </div>
       {/* TODO 하단에 그라데이션 넣으면 좋을듯 */}
     </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

정렬필터 드롭다운 추가하였습니다.

리뷰 정렬
<img width="136" alt="image" src="https://github.com/user-attachments/assets/6642ac06-0a5d-4b65-b11e-c0af6dc93a0d" />

리스트 정렬
<img width="151" alt="image" src="https://github.com/user-attachments/assets/a49b9b8d-6ff8-4fcb-8454-55958b2e1000" />

사용 예시

```jsx
  // 정렬 옵션 변경 콜백 (SortFilter에서 호출)
  const handleSortChange = (sortValue: string) => {
    state 선언 필요
    setSelectedSort(sortValue);
    console.log("API 요청: 정렬 기준 =", sortValue);
  };
  
  리스트 페이지 경우
  <SortFilter variant="list" onSortChange={handleSortChange} />
  리뷰 페이지 경우
  <SortFilter variant="list" onSortChange={handleSortChange} />

```

드롭다운 w 110 -> 120 수정되었습니다
