### PR TITLE
✨ 마이페이지 예약 취소 및 리뷰 작성 기능 추가

### DIFF
--- a/apis/GatheringApi.tsx
+++ b/apis/GatheringApi.tsx
@@ -16,5 +16,10 @@ class GatheringApi {
     axiosInstance.get("/gatherings/joined", {
       params: params || {},
     });
+
+  static deleteGatheringJoined = (
+    gatheringId: number,
+  ): Promise<AxiosResponse> =>
+    axiosInstance.delete(`/gatherings/${gatheringId}/leave`);
 }
 export default GatheringApi;

--- a/apis/ReviewApi.ts
+++ b/apis/ReviewApi.ts
@@ -5,6 +5,13 @@ import {
   ReviewScoreQueryParams,
 } from "@customTypes/reviewApi";
 
+// TODO: 분리된 파일로 옮길 예정
+interface ReviewFormValues {
+  gatheringId: number;
+  score: number;
+  comment: string;
+}
+
 export default class ReviewApi {
   static getReviewData = (params: ReviewQueryParams): Promise<AxiosResponse> =>
     axiosInstance.get("/reviews", { params });
@@ -12,4 +19,7 @@ export default class ReviewApi {
   static getReviewScore = (
     params: ReviewScoreQueryParams,
   ): Promise<AxiosResponse> => axiosInstance.get("/reviews/scores", { params });
+
+  static createReview = (data: ReviewFormValues): Promise<AxiosResponse> =>
+    axiosInstance.post("/reviews", data);
 }

--- a/features/mypage/components/MypageCard.tsx
+++ b/features/mypage/components/MypageCard.tsx
@@ -2,9 +2,15 @@ import Image from "next/image";
 import Button from "@components/common/Button";
 import StateChip from "@features/mypage/components/StateChip";
 import { formatDateTime } from "@utils/dateFormatter";
+import { useDeleteGatheringJoined } from "@features/mypage/hooks/useDeleteGatheringJoinded";
+import useAlertModal from "@hooks/useAlertModal";
+import ModalPortal from "@components/common/ModalPortal";
+import AlertModal from "@components/common/AlertModal";
+import WriteReviewModal from "@features/mypage/components/WriteReviewModal";
+import { useState } from "react";
 
 interface MypageCardProps {
-  id: number;
+  gatheringId: number;
   name: string;
   location: string;
   dateTime: string;
@@ -17,7 +23,7 @@ interface MypageCardProps {
 }
 
 export default function MypageCard({
-  id,
+  gatheringId,
   name,
   location,
   dateTime,
@@ -29,6 +35,29 @@ export default function MypageCard({
   capacity,
 }: MypageCardProps) {
   const formattedDateTime = formatDateTime(dateTime);
+  const { mutate: deleteGatheringJoined } = useDeleteGatheringJoined();
+  const { isOpen, modalOptions, openModal, closeModal, confirmAction } =
+    useAlertModal();
+  const [isWriteReviewModalOpen, setIsWriteReviewModalOpen] = useState(false);
+
+  const closeWriteReviewModal = () => {
+    setIsWriteReviewModalOpen(false);
+  };
+
+  function handleClick(isCompleted: boolean) {
+    if (isCompleted) {
+      setIsWriteReviewModalOpen(true);
+    } else {
+      openModal({
+        text: "정말 모임 참여를 취소하시겠습니까?",
+        hasTwoButton: true,
+        onConfirm: () => {
+          deleteGatheringJoined(gatheringId);
+          alert("모임 참여가 취소되었습니다.");
+        },
+      });
+    }
+  }
 
   return (
     <div className="mb-6 flex flex-col gap-4 border-b-2 border-dotted pb-6 md:flex-row">
@@ -77,13 +106,28 @@ export default function MypageCard({
               variant={isCompleted ? "solid" : "outlined"}
               type="button"
               onClick={() => {
-                // TODO: 버튼 인터랙션 기능 추가
-                console.log("id: ", id);
+                handleClick(isCompleted ?? false);
               }}
             />
           </div>
         )}
       </div>
+      {isWriteReviewModalOpen && (
+        <WriteReviewModal
+          isOpen={isWriteReviewModalOpen}
+          onClose={closeWriteReviewModal}
+          gatheringId={gatheringId}
+        />
+      )}
+      <ModalPortal>
+        <AlertModal
+          isOpen={isOpen}
+          text={modalOptions?.text || ""}
+          hasTwoButton={modalOptions?.hasTwoButton}
+          onClose={closeModal}
+          onConfirm={confirmAction}
+        />
+      </ModalPortal>
     </div>
   );
 }

--- a/features/mypage/components/MypageCardList.tsx
+++ b/features/mypage/components/MypageCardList.tsx
@@ -9,6 +9,8 @@ import {
   useGetGatheringsJoined,
 } from "@features/mypage/hooks/useGetGatheringsJoined";
 import useGetUserInfo from "@features/mypage/hooks/useGetUserInfo";
+import useGetMyReviews from "@features/mypage/hooks/useGetMyReviews";
+import ReviewListwithImage from "@components/common/ReviewListWithImage";
 
 // TODO: Gathering 타입 별도 분리된 파일로 옮길 예정
 interface Gathering {
@@ -29,6 +31,7 @@ export default function MypageCardList({
 }: {
   selectedIndex: number;
 }) {
+  const { data: userInfo, isLoading: isUserInfoLoading } = useGetUserInfo();
   const { data: gatheringsJoined, isLoading: isGatheringJoinedLoading } =
     useGetGatheringsJoined({ reviewed: false });
   const {
@@ -38,8 +41,7 @@ export default function MypageCardList({
   const {
     data: gatheringsIsReviewed,
     isLoading: isGatheringIsReviewedLoading,
-  } = useGetGatheringsJoined({ completed: true, reviewed: true });
-  const { data: userInfo, isLoading: isUserInfoLoading } = useGetUserInfo();
+  } = useGetMyReviews({ userId: userInfo?.data?.id });
   const {
     data: gatheringsCreatedByUser,
     isLoading: isGatheringsCreatedByUserLoading,
@@ -55,7 +57,7 @@ export default function MypageCardList({
         gatheringsJoined.data.map((gathering: Gathering) => (
           <MypageCard
             key={gathering.id}
-            id={gathering.id}
+            gatheringId={gathering.id}
             name={gathering.name}
             location={gathering.location}
             image={gathering.image}
@@ -92,7 +94,7 @@ export default function MypageCardList({
               gatheringsIsNotReviewed.data.map((gathering: Gathering) => (
                 <MypageCard
                   key={gathering.id}
-                  id={gathering.id}
+                  gatheringId={gathering.id}
                   name={gathering.name}
                   location={gathering.location}
                   image={gathering.image}
@@ -108,20 +110,7 @@ export default function MypageCardList({
               </div>
             )
           ) : gatheringsIsReviewed?.data?.length ? (
-            gatheringsIsReviewed?.data?.map((gathering: Gathering) => (
-              //TODO 데이터 확인 불가로 일단 MypageCard 렌더링
-              <MypageCard
-                key={gathering.id}
-                id={gathering.id}
-                name={gathering.name}
-                location={gathering.location}
-                image={gathering.image}
-                dateTime={gathering.dateTime}
-                participantCount={gathering.participantCount}
-                capacity={gathering.capacity}
-                isCompleted
-              />
-            ))
+            <ReviewListwithImage reviewData={gatheringsIsReviewed?.data} />
           ) : (
             <div className="flex h-full w-full flex-1 items-center justify-center">
               아직 작성한 리뷰가 없어요
@@ -134,7 +123,7 @@ export default function MypageCardList({
         gatheringsCreatedByUser?.data?.map((gathering: Gathering) => (
           <MypageCard
             key={gathering.id}
-            id={gathering.id}
+            gatheringId={gathering.id}
             name={gathering.name}
             location={gathering.location}
             image={gathering.image}

--- a/features/mypage/components/WriteReviewModal.tsx
+++ b/features/mypage/components/WriteReviewModal.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import Image from "next/image";
+import Button from "@components/common/Button";
+import { useForm } from "react-hook-form";
+import SvgHeart from "@assets/icon-heart-default.svg";
+import useCreateReview from "@features/mypage/hooks/useCreateReview";
+import { useQueryClient } from "@tanstack/react-query";
+interface WriteReviewModalProps {
+  gatheringId: number;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function WriteReviewModal({
+  gatheringId,
+  isOpen,
+  onClose,
+}: WriteReviewModalProps) {
+  if (!isOpen) return null;
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+    setValue,
+  } = useForm<{ score: number; comment: string }>();
+
+  const queryClient = useQueryClient();
+
+  const { mutate: createReview } = useCreateReview();
+
+  const onSubmit = async (data: { score: number; comment: string }) => {
+    console.log(data, "id:", gatheringId);
+    createReview(
+      {
+        gatheringId,
+        score: data.score,
+        comment: data.comment,
+      },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: ["myReviews"] });
+          onClose();
+        },
+        onError: (error) => {
+          console.error(error);
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="mx-4 w-96 rounded-lg bg-white p-6">
+        <div className="relative flex justify-between">
+          <h2 className="mb-6 text-xl font-semibold">리뷰 쓰기</h2>
+          <button
+            type="button"
+            className="absolute right-0 top-0"
+            onClick={onClose}
+            aria-label="닫기"
+          >
+            <Image src="/image/X.svg" alt="close" width={24} height={24} />
+          </button>
+        </div>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <div className="relative mb-6">
+            <p className="mb-3 text-base font-semibold">
+              만족스러운 경험이었나요?
+            </p>
+            <div className="flex items-center gap-x-2">
+              {[1, 2, 3, 4, 5].map((value) => (
+                <button
+                  key={value}
+                  onClick={() => setValue("score", value)}
+                  className="cursor-pointer"
+                  type="button"
+                >
+                  {/* TODO 애니메이션 구현. 피그마상의 애니메이션 구현하려면 단순히 하나의 svg로는 안될 것 같음. */}
+                  <SvgHeart
+                    className={`transition-all duration-300 ease-in-out ${
+                      watch("score") >= value
+                        ? "fill-mint-400"
+                        : "fill-gray-300"
+                    }`}
+                  />
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="mb-6">
+            <p className="mb-3 text-base font-semibold">
+              경험에 대해 남겨주세요.
+            </p>
+            <textarea
+              id="comment"
+              placeholder="남겨주신 리뷰는 프로그램 운영 및 다른 회원 분들께 큰 도움이 됩니다."
+              className="h-24 w-full resize-none rounded-lg bg-gray-50 p-3 focus:outline-none focus:ring-2 focus:ring-mint-400"
+              {...register("comment")}
+            />
+          </div>
+          <div className="flex justify-end gap-x-2">
+            <Button text="취소" variant="outlined" onClick={onClose} />
+            <Button type="submit" text="저장" variant="solid" />
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/features/mypage/hooks/useCreateReview.ts
+++ b/features/mypage/hooks/useCreateReview.ts
@@ -1,0 +1,12 @@
+import { useMutation } from "@tanstack/react-query";
+import ReviewApi from "@apis/ReviewApi";
+
+export default function useCreateReview() {
+  return useMutation({
+    mutationFn: (data: {
+      gatheringId: number;
+      score: number;
+      comment: string;
+    }) => ReviewApi.createReview(data),
+  });
+}

--- a/features/mypage/hooks/useDeleteGatheringJoinded.ts
+++ b/features/mypage/hooks/useDeleteGatheringJoinded.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import GatheringApi from "@apis/GatheringApi";
+
+export function useDeleteGatheringJoined() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (gatheringId: number) =>
+      GatheringApi.deleteGatheringJoined(gatheringId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["gatheringsJoined"] });
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+}

--- a/features/mypage/hooks/useGetGatheringsJoined.ts
+++ b/features/mypage/hooks/useGetGatheringsJoined.ts
@@ -12,9 +12,19 @@ export function useGetGatheringsCreatedByUser(params: { createdBy: number }) {
 export function useGetGatheringsJoined(params?: {
   completed?: boolean;
   reviewed?: boolean;
+  sortBy?: string;
+  sortOrder?: string;
 }) {
   return useQuery({
     queryKey: ["gatheringsJoined", params],
-    queryFn: () => GatheringApi.getGatheringsJoined(params || {}),
+    queryFn: () => {
+      const updatedParams = {
+        ...params,
+        sortBy: params?.sortBy || "registrationEnd",
+        sortOrder: params?.sortOrder || "desc",
+      };
+
+      return GatheringApi.getGatheringsJoined(updatedParams);
+    },
   });
 }

--- a/features/mypage/hooks/useGetMyReviews.ts
+++ b/features/mypage/hooks/useGetMyReviews.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import ReviewApi from "@apis/ReviewApi";
+
+export default function useGetMyReviews(params: { userId: number }) {
+  return useQuery({
+    queryKey: ["myReviews", params],
+    queryFn: async () => {
+      const response = await ReviewApi.getReviewData(params);
+      return response.data;
+    },
+    enabled: !!params,
+  });
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #80 

## 📝작업 내용

> 마이페이지 작성한 리뷰 영역 데이터 조회 가능합니다.
> "예약 취소하기", "리뷰 작성하기" 버튼을 누르면 모달창이 띄워지고 원하는 기능이 수행됩니다.

### 스크린샷 (선택)
PC View
<img width="1052" alt="스크린샷 2025-02-21 오전 10 29 27" src="https://github.com/user-attachments/assets/ae46cf63-e9da-4324-8d6d-a943a0663716" />
<img width="1057" alt="스크린샷 2025-02-21 오전 10 25 29" src="https://github.com/user-attachments/assets/ee94a4e6-2714-4ccc-803b-b5c8be1b7446" />
<img width="1063" alt="스크린샷 2025-02-21 오전 10 25 39" src="https://github.com/user-attachments/assets/2431988f-767b-409b-a32e-8ac99d5348b5" />

Mobile View
<img width="400" alt="스크린샷 2025-02-21 오전 10 47 32" src="https://github.com/user-attachments/assets/196006ff-288c-4def-b422-bdd6cfa5b510" />
<img width="358" alt="스크린샷 2025-02-21 오전 10 26 12" src="https://github.com/user-attachments/assets/03d299ed-84c7-4b1e-9bb0-b57da2b46fa0" />
<img width="382" alt="스크린샷 2025-02-21 오전 10 27 00" src="https://github.com/user-attachments/assets/a1cbad48-c3d2-4fed-b4a4-897a204523d3" />



## 💬리뷰 요구사항(선택)

> 모달창이 pc 화면에서 너무 작은가? 싶어요. 키우게 된다면 프로필 수정 모달도 같이 키워서 모달창 크기를 통일해야할지...? 아니면 모달의 레이아웃을 공통 컴포넌트로 빼고 그 안의 컨텐츠들은 prop으로 전달하게 해야할까요
> ~~아직 참여 시간이 지나지 않은 아이템이 상단에 보여집니다. << 이부분을 깜빡했네요...나중에 쿼리 수정해야할 것 같습니당 ㅎㅎㅎ...~~ => 쿼리 파라미터 수정했습니다.
