### PR TITLE
✨ 찜하기 페이지 제작

### DIFF
--- a/app/(layout_dafault)/liked/page.tsx
+++ b/app/(layout_dafault)/liked/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import GatheringList from "@components/common/GatheringList";
+import { useGetIdGatherings } from "@features/list/hooks/useGetIdGatherings";
+import Image from "next/image";
+
+export default function LikePage() {
+  const { data: favoriteDate = [] } = useGetIdGatherings();
+
+  return (
+    <div className="flex w-full flex-col pt-6 md:pt-8">
+      <section className="mb-6 flex items-center justify-start gap-4 sm:mb-8">
+        <Image
+          src="image/img-head-saved.svg"
+          alt="review head image"
+          width={72}
+          height={72}
+        />
+        <div>
+          <p className="mt-1 text-2xl font-semibold">찜한 모임</p>
+          <p className="text-sm font-medium">
+            마감되기 전에 지금 바로 참여해보세요
+          </p>
+        </div>
+      </section>
+
+      {favoriteDate.length > 0 ? (
+        <section>
+          <GatheringList gatherings={favoriteDate} />
+        </section>
+      ) : (
+        <div className="mt-10 flex flex-col items-center justify-center">
+          <p className="text-lg font-semibold">💔 찜한 모임이 없습니다.</p>
+          <p className="text-sm text-gray-500">모임을 찾아 찜해보세요!</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/common/GatheringItem.tsx
+++ b/components/common/GatheringItem.tsx
@@ -5,12 +5,16 @@ import ChipInfo from "@components/common/ChipInfo";
 import { GatheringItemProps } from "@customTypes/gathering";
 import { IMAGES } from "@constants/gathering";
 import GatheringStatusBadge from "@features/list/GatheringStatusBadge";
+import { useFavoriteStore } from "@stores/favoriteStore";
 
 export default function GatheringItem({ gathering }: GatheringItemProps) {
   const { date, time } = formatDateTime2(gathering.registrationEnd);
   const isFull = gathering.participantCount >= gathering.capacity;
   const isGatheringOpen = gathering.participantCount >= 5;
   const expired = isExpired(gathering.registrationEnd);
+
+  const { isFavorite, toggleFavorite } = useFavoriteStore();
+  const isLiked = isFavorite(gathering.id);
 
   return (
     <div className="relative w-full">
@@ -47,15 +51,26 @@ export default function GatheringItem({ gathering }: GatheringItemProps) {
                 <ChipInfo info={time} variant="mint" />
               </div>
             </div>
-            {/* 하트 부분 설정 필요 */}
-            <div className="flex items-center justify-center">
+
+            {/* ✅ 하트 버튼 (찜하기) */}
+            <button
+              type="button"
+              onClick={(e) => {
+                e.preventDefault(); // ✅ 부모 Link 클릭 방지
+                toggleFavorite(gathering.id); // ✅ 찜하기 상태 업데이트
+              }}
+              className="flex items-center justify-center"
+            >
               <Image
-                alt={gathering.name || "list-default"}
-                src={IMAGES.HEART_INACTIVE}
+                alt="찜하기"
+                src={isLiked ? IMAGES.HEART_ACTIVE : IMAGES.HEART_INACTIVE}
                 width={48}
                 height={48}
+                className={`transition-all duration-200 ${
+                  isLiked ? "scale-110 opacity-100" : "scale-100 opacity-80"
+                }`}
               />
-            </div>
+            </button>
           </div>
 
           <div className="items-beween flex h-9 justify-between gap-6">

--- a/features/list/hooks/useGetIdGatherings.ts
+++ b/features/list/hooks/useGetIdGatherings.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import GatheringApi from "@apis/GatheringApi";
+import { useFavoriteStore } from "@stores/favoriteStore";
+import { Gathering } from "@customTypes/gathering";
+
+export function useGetIdGatherings() {
+  const favorites = useFavoriteStore((state) => state.favorites);
+
+  return useQuery<Gathering[]>({
+    queryKey: ["favorite-gatherings", favorites],
+    queryFn: async () => {
+      if (favorites.length === 0) return [];
+      const response = await GatheringApi.getGatherings({
+        id: favorites.join(","),
+      });
+      return response.data;
+    },
+    enabled: favorites.length > 0,
+    staleTime: 5000,
+    placeholderData: (previousData) =>
+      favorites.length === 0 ? [] : (previousData ?? []),
+  });
+}

--- a/stores/favoriteStore.ts
+++ b/stores/favoriteStore.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+interface FavoriteStore {
+  favorites: number[];
+  toggleFavorite: (id: number) => void;
+  isFavorite: (id: number) => boolean;
+  clearFavorites: () => void;
+}
+
+export const useFavoriteStore = create<FavoriteStore>()(
+  persist(
+    (set, get) => ({
+      favorites: [],
+
+      toggleFavorite: (id) => {
+        set((state) => {
+          const isAlreadyFavorite = state.favorites.includes(id);
+          return {
+            favorites: isAlreadyFavorite
+              ? state.favorites.filter((favId) => favId !== id)
+              : [...state.favorites, id],
+          };
+        });
+      },
+
+      isFavorite: (id) => get().favorites.includes(id),
+
+      clearFavorites: () => set({ favorites: [] }),
+    }),
+    {
+      name: "favorite-gatherings",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);

--- a/types/gathering.d.ts
+++ b/types/gathering.d.ts
@@ -22,6 +22,7 @@ export interface GatheringListProps {
 }
 
 export interface GatheringParams {
+  id?: string;
   limit?: number;
   offset?: number;
   location?: string | null;


### PR DESCRIPTION

## 📝작업 내용
찜하기 페이지 제작 완료했습니다.

1. 찜하기를 위한 커스텀 훅 만들기
2. persist 스토어 만들기 (Zustand)
3. 버튼 누르면 찜하기에 담기도록 구현
4. 찜하기 상태 반영
5. 찜하기 목록 페이지 구현
6. placeholderData 깜박 거림 방지

남은사항
1. 찜한 모임 필터 추가
2. 하루지나면 장바구니 비우기

![image](https://github.com/user-attachments/assets/7db36227-74db-4d13-8122-37f8df77b817)

![image](https://github.com/user-attachments/assets/b75fa168-55e3-473a-a68a-6d168ad00cbf)


