### PR TITLE
✨ 마감된 모임 처리 기능 작성 

### DIFF
--- a/components/common/GatheringItem.tsx
+++ b/components/common/GatheringItem.tsx
@@ -6,15 +6,16 @@ import { GatheringItemProps } from "@customTypes/gathering";
 import { IMAGES } from "@constants/gathering";
 import GatheringStatusBadge from "@features/list/GatheringStatusBadge";
 import { useFavoriteStore } from "@stores/favoriteStore";
+import { useHiddenGatheringStore } from "@stores/hiddenGatheringStore";
 
 export default function GatheringItem({ gathering }: GatheringItemProps) {
   const { date, time } = formatDateTime2(gathering.registrationEnd);
   const isFull = gathering.participantCount >= gathering.capacity;
   const isGatheringOpen = gathering.participantCount >= 5;
   const expired = isExpired(gathering.registrationEnd);
-
   const { isFavorite, toggleFavorite } = useFavoriteStore();
   const isLiked = isFavorite(gathering.id);
+  const { hideExpiredGathering } = useHiddenGatheringStore();
 
   return (
     <div className="relative w-full">
@@ -139,7 +140,8 @@ export default function GatheringItem({ gathering }: GatheringItemProps) {
             alt="BYE"
             width={48}
             height={48}
-            className="absolute right-6 top-6"
+            className="absolute top-[64%] sm:right-6 sm:top-6"
+            onClick={() => hideExpiredGathering(gathering.id)}
           />
         </div>
       )}

--- a/components/common/GatheringList.tsx
+++ b/components/common/GatheringList.tsx
@@ -1,7 +1,12 @@
 import GatheringItem from "@components/common/GatheringItem";
-import { Gathering, GatheringListProps } from "@customTypes/gathering";
+import { GatheringListProps } from "@customTypes/gathering";
+import { useHiddenGatheringStore } from "@stores/hiddenGatheringStore";
 
 export default function GatheringList({ gatherings }: GatheringListProps) {
+  const hiddenExpiredIds = useHiddenGatheringStore(
+    (state) => state.hiddenExpiredIds,
+  );
+
   if (!Array.isArray(gatherings) || gatherings.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center">
@@ -11,8 +16,9 @@ export default function GatheringList({ gatherings }: GatheringListProps) {
     );
   }
 
-  const filteredGatherings: Gathering[] = gatherings.filter(
-    (gatheringItem) => gatheringItem.canceledAt === null,
+  const filteredGatherings = gatherings.filter(
+    (gathering) =>
+      gathering.canceledAt === null && !hiddenExpiredIds.includes(gathering.id),
   );
 
   if (filteredGatherings.length === 0) {

--- a/stores/hiddenGatheringStore.ts
+++ b/stores/hiddenGatheringStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+interface HiddenGatheringStore {
+  hiddenExpiredIds: number[];
+  hideExpiredGathering: (id: number) => void;
+  isHidden: (id: number) => boolean;
+  clearHidden: () => void;
+}
+
+export const useHiddenGatheringStore = create<HiddenGatheringStore>()(
+  persist(
+    (set, get) => ({
+      hiddenExpiredIds: [],
+
+      hideExpiredGathering: (id) => {
+        set((state) => ({
+          hiddenExpiredIds: [...state.hiddenExpiredIds, id],
+        }));
+      },
+
+      isHidden: (id) => get().hiddenExpiredIds.includes(id),
+
+      clearHidden: () => set({ hiddenExpiredIds: [] }),
+    }),
+    {
+      name: "hidden-gatherings",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);


### PR DESCRIPTION
## 📝작업 내용

유저가 마감된 챌린지를 숨길수 있는 기능을 만들었습니다.
![image](https://github.com/user-attachments/assets/fae6d3fb-5d9c-4bb0-beac-62215e25f608)

마감된 모임에 손 버튼을 클릭하면 로컬스토리지에 id가 쌓이게 되고 필터링하여 보이지 않는 식으로 제작하였습니다.
추가사항으로 마감된 챌린지를 유저가 따로 보관하여 볼 수 있게할지 고민이네요.. 현재는 복구기능 없고 로컬스토리지를 비워야 가능합니다.
이미 마감된 모임이가 굳이 싶기도하고..

