### PR TITLE
✨ 게더링 아이템 수정(모임시간, 지역)

### DIFF
--- a/components/common/GatheringItem.tsx
+++ b/components/common/GatheringItem.tsx
@@ -42,7 +42,9 @@ export default function GatheringItem({ gathering }: GatheringItemProps) {
                   {gathering.name} |{" "}
                 </span>
                 <span className="text-sm font-medium">
-                  {gathering.location}
+                  {gathering.type === "WORKATION"
+                    ? "온라인"
+                    : gathering.location}
                 </span>
               </div>
 

--- a/components/common/GatheringItem.tsx
+++ b/components/common/GatheringItem.tsx
@@ -9,7 +9,7 @@ import { useFavoriteStore } from "@stores/favoriteStore";
 import { useHiddenGatheringStore } from "@stores/hiddenGatheringStore";
 
 export default function GatheringItem({ gathering }: GatheringItemProps) {
-  const { date, time } = formatDateTime2(gathering.registrationEnd);
+  const { date, time } = formatDateTime2(gathering.dateTime);
   const isFull = gathering.participantCount >= gathering.capacity;
   const isGatheringOpen = gathering.participantCount >= 5;
   const expired = isExpired(gathering.registrationEnd);

--- a/features/list/GatheringStatusBadge.tsx
+++ b/features/list/GatheringStatusBadge.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { IMAGES } from "@constants/gathering";
-import { extractHour, isExpired } from "@utils/dateFormatter";
+import { getRemainingHours, isExpired } from "@utils/dateFormatter";
 
 interface GatheringStatusBadgeProps {
   registrationEnd?: string;
@@ -10,13 +10,19 @@ export default function GatheringStatusBadge({
   registrationEnd,
 }: GatheringStatusBadgeProps) {
   const expired = isExpired(registrationEnd);
-  const deadlineTime = extractHour(registrationEnd || "");
+  const remainingHours = getRemainingHours(registrationEnd || "");
 
   return (
     <div className="absolute right-0 top-0 z-10 flex h-8 min-w-[100px] rounded-bl-xl bg-mint-600 p-2">
       <Image src={IMAGES.WATCH} alt="WATCH" width={24} height={24} />
       <p className="text-xs font-medium text-white">
-        {expired ? "마감된 모임" : `${deadlineTime}시 마감 예정`}
+        {expired
+          ? "마감된 모임"
+          : remainingHours <= 0
+            ? "곧 마감"
+            : remainingHours < 24
+              ? `${remainingHours}시간 후 마감  `
+              : `${Math.floor(remainingHours / 24)}일 후 마감`}
       </p>
     </div>
   );

--- a/utils/dateFormatter.ts
+++ b/utils/dateFormatter.ts
@@ -58,6 +58,13 @@ export const isExpired = (dateString?: string): boolean => {
   return targetDate < now;
 };
 
-export const extractHour = (dateString: string): number => {
-  return new Date(dateString).getHours();
+export const getRemainingHours = (dateString: string): number => {
+  if (!dateString) return 0;
+  const now = new Date();
+  const targetTime = new Date(dateString);
+
+  const diffInMs = targetTime.getTime() - now.getTime();
+  const diffInHours = Math.floor(diffInMs / (1000 * 60 * 60));
+
+  return diffInHours;
 };


### PR DESCRIPTION
## 📝작업 내용
게더링 아이템 3가지 내용 수정하였습니다.


<img width="515" alt="image" src="https://github.com/user-attachments/assets/a863acb5-5be4-4e73-8f9a-577f172fb6eb" />

1. 마감뱃지 현재 시간 대비 남은 날짜로 수정(남은일, 남은 시간, 곧마감됨,마감됨)
2. 칩인포 마감시간 ->  모임 만남 시간
3. 구름링 만나는 지역 온라인 수정

차후 구름링 지역 필터 수정 예정입니다
