### PR TITLE
🐛 마이페이지 기존 로직 수정

### DIFF
--- a/features/mypage/components/MypageCard.tsx
+++ b/features/mypage/components/MypageCard.tsx
@@ -68,7 +68,11 @@ export default function MypageCard({
           <div className="flex flex-row gap-x-2">
             <p className="text-lg font-semibold">{getheringData.name}</p>
             <p className="text-lg font-semibold">|</p>
-            <p>{getheringData.location}</p>
+            <p>
+              {getheringData.type === "WORKATION"
+                ? "온라인"
+                : getheringData.location}
+            </p>
           </div>
           <div className="flex flex-row items-center">
             <p className="mr-3">{formattedDateTime}</p>

--- a/features/mypage/components/MypageCardList.tsx
+++ b/features/mypage/components/MypageCardList.tsx
@@ -1,4 +1,5 @@
 // TODO: 로딩 처리는 어떻게 할 것 인지. 필요한지 아닌지 고려해야 함.
+
 "use client";
 
 import MypageCard from "@features/mypage/components/MypageCard";
@@ -8,17 +9,17 @@ import {
   useGetGatheringsCreatedByUser,
   useGetGatheringsJoined,
 } from "@features/mypage/hooks/useGetGatheringsJoined";
-import useGetUserInfo from "@features/mypage/hooks/useGetUserInfo";
 import useGetMyReviews from "@features/mypage/hooks/useGetMyReviews";
 import ReviewListwithImage from "@components/common/ReviewListWithImage";
 import { GatheringJoined } from "@customTypes/gathering";
+import useUserStore from "@stores/userStore";
 
 export default function MypageCardList({
   selectedIndex,
 }: {
   selectedIndex: number;
 }) {
-  const { data: userInfo, isLoading: isUserInfoLoading } = useGetUserInfo();
+  const { id: userId } = useUserStore();
   const { data: gatheringsJoined, isLoading: isGatheringJoinedLoading } =
     useGetGatheringsJoined({ reviewed: false });
   const {
@@ -28,11 +29,11 @@ export default function MypageCardList({
   const {
     data: gatheringsIsReviewed,
     isLoading: isGatheringIsReviewedLoading,
-  } = useGetMyReviews({ userId: userInfo?.data?.id });
+  } = useGetMyReviews({ userId: userId ?? null });
   const {
     data: gatheringsCreatedByUser,
     isLoading: isGatheringsCreatedByUserLoading,
-  } = useGetGatheringsCreatedByUser({ createdBy: userInfo?.data?.id });
+  } = useGetGatheringsCreatedByUser({ createdBy: userId ?? null });
 
   const [selectedReviewTab, setSelectedReviewTab] = useState<
     "writable" | "written"

--- a/features/mypage/components/StateChip.test.tsx
+++ b/features/mypage/components/StateChip.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import StateChip from "./StateChip";
+import StateChip from "@features/mypage/components/StateChip";
 
 describe("StateChip Component Test", () => {
   test("should render '이용 예정' text by default", () => {
@@ -13,12 +13,12 @@ describe("StateChip Component Test", () => {
   });
 
   test("should render '이용 완료' text when isCompleted is true", () => {
-    render(<StateChip isCompleted={true} />);
+    render(<StateChip isCompleted />);
     expect(screen.getByText("이용 완료").textContent).toBe("이용 완료");
   });
 
   test("should render '개설 대기' text when isPending is true", () => {
-    render(<StateChip isCompleted={false} isPending={true} />);
+    render(<StateChip isCompleted={false} isPending />);
     expect(screen.getByText("개설 대기").textContent).toBe("개설 대기");
   });
 

--- a/features/mypage/hooks/useGetGatheringsJoined.ts
+++ b/features/mypage/hooks/useGetGatheringsJoined.ts
@@ -1,11 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import GatheringApi from "@apis/GatheringApi";
 
-export function useGetGatheringsCreatedByUser(params: { createdBy: number }) {
+export function useGetGatheringsCreatedByUser(params: {
+  createdBy: number | null;
+}) {
   return useQuery({
     queryKey: ["gatheringsCreatedByUser", params.createdBy],
     queryFn: () => GatheringApi.getGatherings(params),
-    enabled: !!params,
+    enabled: !!params.createdBy,
   });
 }
 

--- a/features/mypage/hooks/useGetMyReviews.ts
+++ b/features/mypage/hooks/useGetMyReviews.ts
@@ -1,13 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import ReviewApi from "@apis/ReviewApi";
 
-export default function useGetMyReviews(params: { userId: number }) {
+export default function useGetMyReviews(params: { userId: number | null }) {
   return useQuery({
     queryKey: ["myReviews", params],
     queryFn: async () => {
       const response = await ReviewApi.getReviewData(params);
       return response.data;
     },
-    enabled: !!params,
+    enabled: !!params.userId,
   });
 }

--- a/types/gathering.d.ts
+++ b/types/gathering.d.ts
@@ -30,7 +30,7 @@ export interface GatheringParams {
   sortBy?: string | null;
   type?: string | null;
   sortOrder?: "asc" | "desc";
-  createdBy?: number;
+  createdBy?: number | null;
 }
 
 export interface CreateGatheringValues {

--- a/types/reviewApi.d.ts
+++ b/types/reviewApi.d.ts
@@ -4,7 +4,7 @@ export interface CommonReviewParams {
 }
 
 export interface ReviewQueryParams extends CommonReviewParams {
-  userId?: number;
+  userId?: number | null;
   type?: GatheringType;
   location?: string;
   date?: string;


### PR DESCRIPTION
## #️⃣연관된 이슈

>

## 📝작업 내용

> 사용자 정보를 전역적으로 관리하게 되면서 기존 로직 수정했습니다. (까먹고 있다가 이제 발견했네요...🥹)
> 사용자 아이디를 쿼리 파라미터로 전달해야하는 부분들 수정했습니다.
> useGetUserInfo의 경우 사용자 정보 전역관리로 인해 마이페이지에서는 필요없어진 커스텀훅인데 혹시 사용을 해야하는 페이지가 있을까요? 없다면 삭제하고 있다면 파일 위치를 옮겨야할 것 같습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> useGetUserInfo의 경우 사용자 정보 전역관리로 인해 마이페이지에서는 필요없어진 커스텀훅인데 혹시 사용을 해야하는 페이지가 있을까요? 없다면 삭제하고 있다면 파일 위치를 옮겨야할 것 같습니다.
