### PR TITLE
✨ 데이트정렬 모임만들기 시간 utc

### DIFF
--- a/components/common/DateFilter.tsx
+++ b/components/common/DateFilter.tsx
@@ -83,21 +83,43 @@ export default function DateFilter({
   const [tempDate, setTempDate] = useState<Date | null>(null);
   const [isOpen, setIsOpen] = useState(false);
 
-  const dateFormat = showTimeSelect ? "yyyy-MM-dd HH:mm" : "yyyy-MM-dd";
-
   const handleSelect = (date: Date | null) => {
     setTempDate(date);
   };
 
   const handleApply = () => {
+    if (!tempDate) {
+      setAppliedDate(null);
+      setIsOpen(false);
+      onDateSelect?.(undefined);
+      return;
+    }
+
+    const utcDate = showTimeSelect
+      ? new Date(tempDate.getTime() - 9 * 60 * 60 * 1000)
+      : tempDate;
+    const formatted = format(
+      utcDate,
+      showTimeSelect ? "yyyy-MM-dd'T'HH:mm'Z'" : "yyyy-MM-dd",
+    );
+
+    console.log("formatted", formatted);
+
     setAppliedDate(tempDate);
     setIsOpen(false);
-
-    if (onDateSelect) {
-      const formatted = tempDate ? format(tempDate, dateFormat) : undefined;
-      onDateSelect(formatted);
-    }
+    onDateSelect?.(formatted);
   };
+
+  const getDisplayValue = () => {
+    if (!appliedDate) return "";
+    if (showTimeSelect) {
+      const utcDate = new Date(appliedDate.getTime() - 9 * 60 * 60 * 1000);
+      return format(utcDate, "yyyy-MM-dd HH:mm");
+    }
+    return format(appliedDate, "yyyy-MM-dd");
+  };
+
+  const displayValue = getDisplayValue();
 
   const handleReset = () => {
     setTempDate(null);
@@ -113,8 +135,6 @@ export default function DateFilter({
     setTempDate(appliedDate);
     setIsOpen(true);
   };
-
-  const displayValue = appliedDate ? format(appliedDate, dateFormat) : "";
 
   if (!showTimeSelect) {
     return (


### PR DESCRIPTION
## 📝작업 내용


모임만들기 시간 utc 변경완료했습니다.
 프론트에서 모임날짜 시간을 utc (한국 -9시간) 형태로 보내고 사용자에게는 한국시간에 맞게 보여주는 로직 추가 하였습니다.