### PR TITLE
✨ 마이페이지에서 상세 페이지로 이동하는 링크 추가

### DIFF
--- a/features/mypage/components/MyProfile.test.tsx
+++ b/features/mypage/components/MyProfile.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import MyProfile from "@features/mypage/components/MyProfile";
+import useUserStore from "@stores/userStore";
+import { DEFAULT_USER_IMAGE } from "@constants/user";
+import { ImgHTMLAttributes } from "react";
+
+jest.mock("@stores/userStore", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({})),
+}));
+jest.mock("@features/mypage/components/EditProfileModal", () =>
+  jest.fn(({ isOpen, onClose }) =>
+    isOpen ? (
+      <div>
+        <div>Mocked EditProfileModal</div>
+        <button onClick={onClose} aria-label="취소" type="button">
+          취소
+        </button>
+      </div>
+    ) : null,
+  ),
+);
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
+}));
+
+describe("MyProfile Component Test", () => {
+  const mockUserInfo = {
+    image: "/image/test.png",
+    name: "김에버",
+    companyName: "테스트 회사",
+    email: "test@example.com",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useUserStore as jest.MockedFunction<typeof useUserStore>).mockReturnValue(
+      mockUserInfo,
+    );
+  });
+
+  test("should display user profile image when user data is available", () => {
+    render(<MyProfile />);
+
+    const profileImage = screen.getByRole("img", {
+      name: "profile image",
+    });
+
+    expect(profileImage).toHaveAttribute("src", "/image/test.png");
+  });
+
+  test("should display default profile image when user image is not provided", () => {
+    (useUserStore as jest.MockedFunction<typeof useUserStore>).mockReturnValue({
+      image: null,
+    });
+
+    render(<MyProfile />);
+
+    const profileImage = screen.getByRole("img", {
+      name: "profile image",
+    });
+
+    expect(profileImage).toHaveAttribute("src", DEFAULT_USER_IMAGE);
+  });
+
+  test("should display user name when user data is available", () => {
+    render(<MyProfile />);
+    expect(screen.getByText("김에버")).toBeInTheDocument();
+  });
+
+  test("should display user company name when user data is available", () => {
+    render(<MyProfile />);
+
+    expect(screen.getByText("테스트 회사")).toBeInTheDocument();
+  });
+
+  test("should display user email when user data is available", () => {
+    render(<MyProfile />);
+    expect(screen.getByText("test@example.com")).toBeInTheDocument();
+  });
+
+  test("should open the modal when edit button is clicked", () => {
+    render(<MyProfile />);
+
+    const editButton = screen.getByRole("button", { name: "프로필 수정" });
+    fireEvent.click(editButton);
+
+    expect(screen.getByText("Mocked EditProfileModal")).toBeInTheDocument();
+  });
+
+  test("should close the modal when close button is clicked", () => {
+    render(<MyProfile />);
+
+    const editButton = screen.getByRole("button", { name: "프로필 수정" });
+    fireEvent.click(editButton);
+
+    const closeButton = screen.getByRole("button", { name: "취소" });
+    fireEvent.click(closeButton);
+
+    expect(
+      screen.queryByText("Mocked EditProfileModal"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/features/mypage/components/MypageCard.test.tsx
+++ b/features/mypage/components/MypageCard.test.tsx
@@ -1,0 +1,212 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import MypageCard from "@features/mypage/components/MypageCard";
+import useModalStore from "@stores/modalStore";
+import { useDeleteGatheringJoined } from "@features/mypage/hooks/useDeleteGatheringJoinded";
+import mockRouter from "next-router-mock";
+import { MemoryRouterProvider } from "next-router-mock/MemoryRouterProvider";
+import { GatheringJoined } from "@customTypes/gathering";
+
+jest.mock("@stores/modalStore", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({})),
+}));
+
+jest.mock("@features/mypage/hooks/useDeleteGatheringJoinded", () => ({
+  useDeleteGatheringJoined: jest.fn().mockReturnValue({
+    mutate: jest.fn().mockResolvedValue("success"),
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+jest.mock("@features/mypage/components/WriteReviewModal", () => ({
+  __esModule: true,
+  default: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
+    isOpen ? (
+      <div>
+        <div>Mocked WriteReviewModal</div>
+        <button onClick={onClose} aria-label="취소" type="button">
+          취소
+        </button>
+      </div>
+    ) : null,
+}));
+
+describe("MypageCard Component", () => {
+  const currentDate = new Date();
+  const registrationEnd = new Date(currentDate);
+  const dateTime = new Date(currentDate);
+  registrationEnd.setHours(currentDate.getHours() + 1);
+  dateTime.setDate(currentDate.getDate() + 1);
+
+  const completedGatheringData = {
+    id: 1234,
+    name: "테스트 모임",
+    image: "/image/test.png",
+    dateTime: dateTime.toISOString(),
+    participantCount: 5,
+    capacity: 10,
+    type: "NOTWORKATION",
+    location: "서울",
+    isCompleted: true,
+    registrationEnd: registrationEnd.toISOString(),
+    canceledAt: null,
+    createdBy: 1,
+    joinedAt: currentDate.toISOString(),
+    isReviewed: false,
+  };
+  const pendingOnlineGatheringData = {
+    id: 1,
+    name: "테스트 모임",
+    image: "/image/test.png",
+    dateTime: dateTime.toISOString(),
+    participantCount: 5,
+    capacity: 10,
+    type: "WORKATION",
+    location: "서울",
+    isCompleted: false,
+    registrationEnd: registrationEnd.toISOString(),
+    canceledAt: null,
+    createdBy: 1,
+    joinedAt: currentDate.toISOString(),
+    isReviewed: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should display gathering name, location, and participant count", () => {
+    render(<MypageCard gatheringData={completedGatheringData} />);
+
+    expect(screen.getByText("테스트 모임")).toBeInTheDocument();
+    expect(screen.getByText("서울")).toBeInTheDocument();
+    expect(screen.getByText("5/10")).toBeInTheDocument();
+  });
+
+  test("should display '온라인' as location when gathering type is WORKATION", () => {
+    render(<MypageCard gatheringData={pendingOnlineGatheringData} />);
+
+    expect(screen.getByText("테스트 모임")).toBeInTheDocument();
+    expect(screen.getByText("온라인")).toBeInTheDocument();
+    expect(screen.getByText("5/10")).toBeInTheDocument();
+  });
+
+  test("should navigate to list-detail page when '자세히 보기' is clicked", () => {
+    render(<MypageCard gatheringData={completedGatheringData} />, {
+      wrapper: MemoryRouterProvider,
+    });
+
+    fireEvent.click(screen.getByText("자세히 보기"));
+
+    expect(mockRouter.asPath).toEqual(
+      `/list-detail/${completedGatheringData.id}`,
+    );
+  });
+
+  test("should open WriteReviewModal when completed gathering's '리뷰 작성하기' button is clicked", () => {
+    render(<MypageCard gatheringData={completedGatheringData} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /리뷰 작성하기/ }));
+    expect(screen.getByText("Mocked WriteReviewModal")).toBeInTheDocument();
+  });
+
+  test("should close WriteReviewModal when '취소' button is clicked", () => {
+    render(<MypageCard gatheringData={completedGatheringData} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /리뷰 작성하기/ }));
+    fireEvent.click(screen.getByRole("button", { name: "취소" }));
+
+    expect(
+      screen.queryByText("Mocked WriteReviewModal"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("should call openModal with cancellation message when '예약 취소하기' button is clicked", () => {
+    const mockOpenModal = jest.fn();
+    (
+      useModalStore as jest.MockedFunction<typeof useModalStore>
+    ).mockReturnValueOnce({
+      isOpen: false,
+      modalOptions: null,
+      openModal: mockOpenModal,
+      closeModal: jest.fn(),
+      confirmAction: jest.fn(),
+    });
+
+    render(<MypageCard gatheringData={pendingOnlineGatheringData} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /예약 취소하기/ }));
+
+    expect(mockOpenModal).toHaveBeenCalledWith({
+      text: "정말 모임 참여를 취소하시겠습니까?",
+      hasTwoButton: true,
+      onConfirm: expect.any(Function),
+    });
+  });
+
+  test("should call deleteGatheringJoined when cancellation is confirmed", async () => {
+    const mockDeleteGatheringJoined = jest.fn();
+
+    (useDeleteGatheringJoined as jest.Mock).mockReturnValue({
+      mutate: mockDeleteGatheringJoined,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    const mockOpenModal = jest.fn();
+    const mockConfirmAction = jest.fn();
+    (
+      useModalStore as jest.MockedFunction<typeof useModalStore>
+    ).mockReturnValueOnce({
+      isOpen: false,
+      modalOptions: null,
+      openModal: mockOpenModal,
+      closeModal: jest.fn(),
+      confirmAction: mockConfirmAction,
+    });
+
+    render(<MypageCard gatheringData={pendingOnlineGatheringData} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /예약 취소하기/ }));
+
+    await waitFor(() =>
+      expect(mockOpenModal).toHaveBeenCalledWith({
+        text: "정말 모임 참여를 취소하시겠습니까?",
+        hasTwoButton: true,
+        onConfirm: expect.any(Function),
+      }),
+    );
+
+    const { onConfirm } = mockOpenModal.mock.calls[0][0];
+    onConfirm();
+
+    expect(mockDeleteGatheringJoined).toHaveBeenCalledWith(
+      pendingOnlineGatheringData.id,
+    );
+  });
+
+  test("should disable the button when registration has ended and gathering is not completed", async () => {
+    const nonCancelableGatheringData = {
+      id: 2,
+      name: "종료된 모임",
+      type: "OFFLINE",
+      location: "부산",
+      dateTime: "2025-03-02T12:00:00Z",
+      registrationEnd: "2025-03-01T12:00:00Z",
+      image: "/test-image.jpg",
+      participantCount: 5,
+      capacity: 10,
+      isCompleted: false,
+      canceledAt: null,
+    } as GatheringJoined;
+
+    render(<MypageCard gatheringData={nonCancelableGatheringData} />);
+
+    const button = screen.getByRole("button", { name: "예약 취소하기" });
+
+    expect(button).toBeDisabled();
+  });
+});

--- a/features/mypage/components/MypageCard.tsx
+++ b/features/mypage/components/MypageCard.tsx
@@ -6,9 +6,10 @@ import { useDeleteGatheringJoined } from "@features/mypage/hooks/useDeleteGather
 import useModalStore from "@stores/modalStore";
 import WriteReviewModal from "@features/mypage/components/WriteReviewModal";
 import { useState } from "react";
-import { MIN_PARTICIPANTS } from "@constants/gathering";
+import { MIN_PARTICIPANTS, IMAGES } from "@constants/gathering";
 import { GatheringJoined } from "@customTypes/gathering";
 import GatheringClosureNotice from "@components/common/GatheringClosureNotice";
+import Link from "next/link";
 
 interface MypageCardProps {
   gatheringData: GatheringJoined;
@@ -93,8 +94,8 @@ export default function MypageCard({
             </p>
           </div>
         </div>
-        {!isMadeByMe && (
-          <div className="md:absolute md:bottom-0 md:left-0">
+        <div className="bottom-0 flex w-full items-center justify-between md:absolute">
+          {!isMadeByMe && (
             <Button
               text={
                 gatheringData.isCompleted ? "리뷰 작성하기" : "예약 취소하기"
@@ -107,8 +108,20 @@ export default function MypageCard({
                 handleClick();
               }}
             />
-          </div>
-        )}
+          )}
+          <Link
+            href={`/list-detail/${gatheringData.id}`}
+            className="absolute bottom-0 right-0 flex gap-x-2"
+          >
+            <p className="text-base font-semibold text-mint-600">자세히 보기</p>
+            <Image
+              alt="join_arrow"
+              src={IMAGES.ARROW_RIGHT}
+              width={18}
+              height={18}
+            />
+          </Link>
+        </div>
       </div>
       <GatheringClosureNotice isCanceled={!!gatheringData.canceledAt} />
       {isWriteReviewModalOpen && (


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> 마이페이지의 모임 목록에서 해당 모임의 상세 페이지로 이동하는 Link를 추가했습니다.
> MypageCard와 MyProfile 테스트코드 작성했습니다.

### 스크린샷 (선택)
PC View
<img width="1055" alt="스크린샷 2025-03-10 오후 3 10 47" src="https://github.com/user-attachments/assets/db8cc96b-def6-49c1-b666-df0d0ae7ad4a" />

Mobile View
<img width="405" alt="스크린샷 2025-03-10 오후 3 11 37" src="https://github.com/user-attachments/assets/9223ba97-e77f-4b33-9345-3cf3da06accc" />


## 💬리뷰 요구사항(선택)

> 현재는 카드요소가 아닌 카드 내부의 "자세히 보기"를 눌러야 이동이 가능하게 해놨는데 카드 자체를 눌렀을 때 이동이 가능하게 해야할지 고민을 좀 해봐야할 것 같습니다.
