### PR TITLE
✨ 마이페이지, 리뷰페이지에서 상세페이지로 이동하는 링크 추가

### DIFF
--- a/components/common/ReviewItemWithImage.tsx
+++ b/components/common/ReviewItemWithImage.tsx
@@ -7,6 +7,7 @@ import { formatDate } from "@utils/dateFormatter";
 
 import { GATHERING_TYPE_MAP, GatheringType } from "@constants/gatheringType";
 import { DEFAULT_USER_IMAGE } from "@constants/user";
+import Link from "next/link";
 
 export default function ReviewItemWithImage({
   review,
@@ -33,13 +34,16 @@ export default function ReviewItemWithImage({
             <p className="h-[3.75rem] overflow-hidden text-sm font-medium md:h-[2.5rem]">
               {review?.comment}
             </p>
-            <p className="flex flex-row items-center gap-[0.375rem] text-xs font-medium">
-              <span>
-                {gatheringType} {review?.Gathering?.name} 이용
-              </span>
-              <span>·</span>
-              <span>{review?.Gathering?.location}</span>
-            </p>
+            <Link href={`/list-detail/${review?.Gathering?.id}`}>
+              <p className="flex flex-row items-center gap-[0.375rem] text-xs font-medium">
+                <span>
+                  {gatheringType} {review?.Gathering?.name} 이용
+                </span>
+                <span>·</span>
+                <span>{review?.Gathering?.location}</span>
+                <span className="pl-1 font-semibold text-gray-500"> 〉 </span>
+              </p>
+            </Link>
           </div>
           <div className="flex flex-row items-center gap-3">
             {hasUserInfo && (

--- a/features/mypage/components/MypageCard.test.tsx
+++ b/features/mypage/components/MypageCard.test.tsx
@@ -76,6 +76,12 @@ describe("MypageCard Component", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+  beforeAll(() => {
+    global.alert = jest.fn();
+  });
+  afterAll(() => {
+    (global.alert as jest.Mock).mockRestore();
+  });
 
   test("should display gathering name, location, and participant count", () => {
     render(<MypageCard gatheringData={completedGatheringData} />);
@@ -93,12 +99,12 @@ describe("MypageCard Component", () => {
     expect(screen.getByText("5/10")).toBeInTheDocument();
   });
 
-  test("should navigate to list-detail page when '자세히 보기' is clicked", () => {
+  test("should navigate to list-detail page when gathering name is clicked", () => {
     render(<MypageCard gatheringData={completedGatheringData} />, {
       wrapper: MemoryRouterProvider,
     });
 
-    fireEvent.click(screen.getByText("자세히 보기"));
+    fireEvent.click(screen.getByText("테스트 모임"));
 
     expect(mockRouter.asPath).toEqual(
       `/list-detail/${completedGatheringData.id}`,

--- a/features/mypage/components/MypageCard.tsx
+++ b/features/mypage/components/MypageCard.tsx
@@ -6,7 +6,7 @@ import { useDeleteGatheringJoined } from "@features/mypage/hooks/useDeleteGather
 import useModalStore from "@stores/modalStore";
 import WriteReviewModal from "@features/mypage/components/WriteReviewModal";
 import { useState } from "react";
-import { MIN_PARTICIPANTS, IMAGES } from "@constants/gathering";
+import { MIN_PARTICIPANTS } from "@constants/gathering";
 import { GatheringJoined } from "@customTypes/gathering";
 import GatheringClosureNotice from "@components/common/GatheringClosureNotice";
 import Link from "next/link";
@@ -69,15 +69,18 @@ export default function MypageCard({
           />
         )}
         <div className="flex flex-col gap-y-1">
-          <div className="flex flex-row gap-x-2">
-            <p className="text-lg font-semibold">{gatheringData.name}</p>
-            <p className="text-lg font-semibold">|</p>
-            <p>
-              {gatheringData.type === "WORKATION"
-                ? "온라인"
-                : gatheringData.location}
-            </p>
-          </div>
+          <Link href={`/list-detail/${gatheringData.id}`}>
+            <div className="flex flex-row gap-x-2">
+              <p className="text-lg font-semibold">{gatheringData.name}</p>
+              <p className="text-lg font-semibold">|</p>
+              <p>
+                {gatheringData.type === "WORKATION"
+                  ? "온라인"
+                  : gatheringData.location}
+              </p>
+              <span className="pl-1 font-semibold text-gray-500"> 〉 </span>
+            </div>
+          </Link>
           <div className="flex flex-row items-center">
             <p className="mr-3">
               {formattedDate} ・ {formattedTime}
@@ -109,18 +112,6 @@ export default function MypageCard({
               }}
             />
           )}
-          <Link
-            href={`/list-detail/${gatheringData.id}`}
-            className="absolute bottom-0 right-0 flex gap-x-2"
-          >
-            <p className="text-base font-semibold text-mint-600">자세히 보기</p>
-            <Image
-              alt="join_arrow"
-              src={IMAGES.ARROW_RIGHT}
-              width={18}
-              height={18}
-            />
-          </Link>
         </div>
       </div>
       <GatheringClosureNotice isCanceled={!!gatheringData.canceledAt} />

--- a/features/mypage/components/MypageCardList.tsx
+++ b/features/mypage/components/MypageCardList.tsx
@@ -71,9 +71,13 @@ export default function MypageCardList({
           </div>
           {selectedReviewTab === "writable" &&
             (gatheringsIsNotReviewed?.data?.length ? (
-              gatheringsIsNotReviewed.data.map((gathering: GatheringJoined) => (
-                <MypageCard key={gathering.id} gatheringData={gathering} />
-              ))
+              gatheringsIsNotReviewed.data
+                .filter(
+                  (gathering: GatheringJoined) => gathering.canceledAt === null,
+                )
+                .map((gathering: GatheringJoined) => (
+                  <MypageCard key={gathering.id} gatheringData={gathering} />
+                ))
             ) : (
               <div className="flex h-full w-full flex-1 items-center justify-center">
                 아직 작성 가능한 리뷰가 없어요
@@ -82,7 +86,9 @@ export default function MypageCardList({
 
           {selectedReviewTab !== "writable" &&
             (gatheringsIsReviewed?.data?.length ? (
-              <ReviewListwithImage reviewData={gatheringsIsReviewed.data} />
+              <div className="pb-6">
+                <ReviewListwithImage reviewData={gatheringsIsReviewed.data} />
+              </div>
             ) : (
               <div className="flex h-full w-full flex-1 items-center justify-center">
                 아직 작성한 리뷰가 없어요


### PR DESCRIPTION
## #️⃣연관된 이슈

>

## 📝작업 내용

> - 마이페이지, 리뷰페이지에서 상세페이지로 이동하는 링크 추가했습니다. 회의 결과대로 모임 이름 부분을 클릭하면 이동할 수 있게 수정 및 추가했습니다.
> - 마이페이지 나의 리뷰에서 모집 취소된 모임이 조회되던 오류 수정했습니다.

### 스크린샷 (선택)
PC View
- 마이페이지
<img width="1147" alt="스크린샷 2025-03-11 오전 11 14 24" src="https://github.com/user-attachments/assets/01d3e500-f96f-4f8c-b4c4-842347b85ad2" />

- 모든 리뷰
<img width="1149" alt="스크린샷 2025-03-11 오전 11 14 42" src="https://github.com/user-attachments/assets/e69f73ac-f925-4a46-b43b-11604e24aaae" />

Mobile View
- 마이페이지
<img width="412" alt="스크린샷 2025-03-11 오전 11 16 34" src="https://github.com/user-attachments/assets/edcc7bc7-2e66-4df4-a4b7-01db753b6b7a" />

- 모든 리뷰
<img width="407" alt="스크린샷 2025-03-11 오전 11 16 46" src="https://github.com/user-attachments/assets/17000503-952e-4d2d-a496-f871108d5c21" />

## 💬리뷰 요구사항(선택)

> 현재는 〉를 추가하여 클릭 유도를 진행하고 있습니다. 더 좋은 아이디어가 있으면 언제든지 알려주세요!
