### PR TITLE
♻️ EditProfileModal 컴포넌트 리팩토링

### DIFF
--- a/features/mypage/components/EditProfileModal.test.tsx
+++ b/features/mypage/components/EditProfileModal.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import EditProfileModal from "@features/mypage/components/EditProfileModal";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ImgHTMLAttributes } from "react";
+
+const queryClient = new QueryClient();
+
+const mockOnClose = jest.fn();
+const mockMutate = jest.fn();
+
+jest.mock("@features/mypage/hooks/useUpdateUserInfo", () => ({
+  __esModule: true,
+  default: () => ({
+    mutate: mockMutate,
+  }),
+}));
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
+}));
+
+describe("EditProfileModal Component Test", () => {
+  const mockUserInfo = {
+    companyName: "테스트 회사",
+    image: "/image/test.png",
+  };
+
+  function renderComponent() {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <EditProfileModal
+          isOpen
+          onClose={mockOnClose}
+          userInfo={mockUserInfo}
+        />
+      </QueryClientProvider>,
+    );
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should display user profile image", () => {
+    renderComponent();
+
+    const profileImage = screen.getByRole("img", {
+      name: "profile image",
+    });
+    expect(profileImage).toBeInTheDocument();
+    expect(profileImage).toHaveAttribute("src", "/image/test.png");
+  });
+
+  test("should edit profile image when profile image edit button is clicked", async () => {
+    renderComponent();
+
+    const profileImageButton = screen.getByLabelText("프로필 이미지 수정");
+    fireEvent.click(profileImageButton);
+
+    const fileInput = screen.getByLabelText(
+      "프로필 이미지 수정",
+    ) as HTMLInputElement;
+
+    const file = new File(["dummy content"], "new.png", { type: "image/png" });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(fileInput.files?.[0]).toBe(file);
+  });
+
+  test("should display user company name", () => {
+    renderComponent();
+
+    const input = screen.getByRole("textbox", { name: "직업 / 소속" });
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("테스트 회사");
+  });
+
+  test("should edit company name", () => {
+    renderComponent();
+
+    const input = screen.getByRole("textbox", { name: "직업 / 소속" });
+    fireEvent.change(input, { target: { value: "새 회사명" } });
+    expect(input).toHaveValue("새 회사명");
+  });
+
+  test("should call onSubmit function when save button is clicked", async () => {
+    renderComponent();
+    const saveButton = screen.getByRole("button", { name: "저장" });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(mockMutate).toHaveBeenCalled());
+  });
+
+  test("should close modal when cancel button is clicked", () => {
+    renderComponent();
+
+    const cancelButton = screen.getByText("취소");
+    fireEvent.click(cancelButton);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("should close modal when close button is clicked", () => {
+    renderComponent();
+    const closeButton = screen.getByRole("button", { name: "닫기" });
+    fireEvent.click(closeButton);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("should not render modal when isOpen is false", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EditProfileModal
+          isOpen={false}
+          onClose={mockOnClose}
+          userInfo={mockUserInfo}
+        />
+      </QueryClientProvider>,
+    );
+
+    const modal = screen.queryByText("프로필 수정하기");
+    expect(modal).not.toBeInTheDocument();
+  });
+});

--- a/features/mypage/hooks/useEditProfile.ts
+++ b/features/mypage/hooks/useEditProfile.ts
@@ -1,0 +1,82 @@
+import { useEffect, RefObject } from "react";
+import { useForm } from "react-hook-form";
+import { useQueryClient } from "@tanstack/react-query";
+import useUpdateUserInfo from "@features/mypage/hooks/useUpdateUserInfo";
+import { FormValues } from "@customTypes/form";
+import { AxiosError } from "axios";
+import useUserStore from "@stores/userStore";
+import { DEFAULT_USER_IMAGE } from "@constants/user";
+import validateImageSize from "@features/mypage/utils/fileUtils";
+
+export default function useEditProfile(
+  userInfo: { companyName: string | null; image: string | null },
+  onClose: () => void,
+  fileInputRef: RefObject<HTMLInputElement | null>,
+) {
+  const { mutate: updateUserInfo } = useUpdateUserInfo();
+  const queryClient = useQueryClient();
+  const { register, handleSubmit, setValue, formState, trigger, watch } =
+    useForm<FormValues>();
+
+  useEffect(() => {
+    if (userInfo) {
+      setValue("companyName", userInfo.companyName ?? "");
+      setValue("image", userInfo.image ?? DEFAULT_USER_IMAGE);
+    }
+  }, [userInfo, setValue]);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    const isValidImageFile = validateImageSize(file);
+
+    if (isValidImageFile) {
+      setValue("image", URL.createObjectURL(file));
+    } else {
+      alert("파일 크기는 5MB 이하이어야 합니다.");
+    }
+  };
+
+  const onSubmit = async (data: FormValues) => {
+    const file = fileInputRef.current?.files?.[0];
+    const formData = new FormData();
+    formData.append("companyName", data.companyName ?? "");
+    formData.append("image", file || (data.image ?? ""));
+
+    updateUserInfo(formData, {
+      onSuccess: () => {
+        useUserStore.getState().setUser({
+          ...useUserStore.getState(),
+          companyName: data.companyName ?? null,
+          image: data.image ?? null,
+        });
+        queryClient.invalidateQueries({ queryKey: ["userInfo"] });
+        onClose();
+      },
+      onError: (error: Error) => {
+        const axiosError = error as AxiosError;
+        const errorMessage = axiosError.isAxiosError
+          ? (axiosError.response?.data as { message?: string })?.message ||
+            "에러가 발생했습니다."
+          : axiosError.message;
+
+        alert(errorMessage);
+      },
+    });
+  };
+
+  return {
+    register,
+    handleSubmit,
+    setValue,
+    formState,
+    trigger,
+    watch,
+    handleFileChange,
+    onSubmit,
+  };
+}

--- a/features/mypage/utils/fileUtils.test.ts
+++ b/features/mypage/utils/fileUtils.test.ts
@@ -1,0 +1,21 @@
+import validateImageSize from "@features/mypage/utils/fileUtils";
+
+describe("validateImageSize", () => {
+  test("should return true when file size is less than 5MB", () => {
+    const file = new File(["dummy content"], "test.jpg", {
+      type: "image/jpeg",
+    });
+    Object.defineProperty(file, "size", { value: 4 * 1024 * 1024 });
+
+    expect(validateImageSize(file)).toBe(true);
+  });
+
+  test("should return false when file size exceeds 5MB.", () => {
+    const file = new File(["dummy content"], "test.jpg", {
+      type: "image/jpeg",
+    });
+    Object.defineProperty(file, "size", { value: 6 * 1024 * 1024 });
+
+    expect(validateImageSize(file)).toBe(false);
+  });
+});

--- a/features/mypage/utils/fileUtils.ts
+++ b/features/mypage/utils/fileUtils.ts
@@ -1,0 +1,5 @@
+export default function validateImageSize(file: File) {
+  const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+  return file.size < MAX_FILE_SIZE;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> - EditProfileModal 컴포넌트의 뷰와 비즈니스 로직을 분리하여, 로직을 커스텀 훅(useEditProfile)으로 분리하였습니다.
> - 이미지 파일 크기 검증하는 함수를 별도의 유틸 함수로 분리하였습니다.
> - EditProfileModal 테스트코드 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

>
