### PR TITLE
♻️ 리뷰페이지 리팩토링

### DIFF
--- a/components/common/ReviewItemWithImage.tsx
+++ b/components/common/ReviewItemWithImage.tsx
@@ -38,9 +38,7 @@ export default function ReviewItemWithImage({
         />
       </div>
 
-      <div
-        className={`flex ${isShowFullComment ? "h-auto" : "h-[10.5rem] md:h-[9.75rem]"} flex-col items-start justify-between gap-6 self-stretch md:flex-1`}
-      >
+      <div className="flex flex-col items-start justify-between gap-8 self-stretch md:flex-1 md:gap-6">
         <div className="flex flex-col items-start gap-2 self-stretch">
           <div className="flex flex-col items-start gap-[0.625rem] self-stretch">
             <ReviewRating score={review?.score} />

--- a/components/common/ReviewItemWithImage.tsx
+++ b/components/common/ReviewItemWithImage.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import ReviewRating from "@components/common/ReviewRating";
 import Image from "next/image";
 import UnderLine from "@assets/underline.svg";
@@ -8,11 +9,21 @@ import { formatDate } from "@utils/dateFormatter";
 import { GATHERING_TYPE_MAP, GatheringType } from "@constants/gatheringType";
 import { DEFAULT_USER_IMAGE } from "@constants/user";
 import Link from "next/link";
+import { truncateText } from "@utils/truncateText";
 
 export default function ReviewItemWithImage({
   review,
   hasUserInfo,
 }: ReviewItemWithImageProps) {
+  const [isMoreView, setIsMoreView] = useState(false);
+  const [isShowFullComment, setIsShowText] = useState(false);
+
+  useEffect(() => {
+    if (review?.comment) {
+      setIsMoreView(review.comment.length > 60);
+    }
+  }, [review?.comment]);
+
   const gatheringType =
     GATHERING_TYPE_MAP[review?.Gathering?.type as GatheringType] || "";
 
@@ -26,14 +37,34 @@ export default function ReviewItemWithImage({
           className="shrink-0 rounded-3xl object-cover"
         />
       </div>
-      <div className="flex h-[10.5rem] flex-col items-start justify-between self-stretch md:h-[9.75rem] md:flex-1">
+
+      <div
+        className={`flex ${isShowFullComment ? "h-auto" : "h-[10.5rem] md:h-[9.75rem]"} flex-col items-start justify-between gap-6 self-stretch md:flex-1`}
+      >
         <div className="flex flex-col items-start gap-2 self-stretch">
           <div className="flex flex-col items-start gap-[0.625rem] self-stretch">
             <ReviewRating score={review?.score} />
-            {/* // TODO height&overflow 임시 적용 */}
-            <p className="h-[3.75rem] overflow-hidden text-sm font-medium md:h-[2.5rem]">
-              {review?.comment}
-            </p>
+            <div className="relative text-sm font-medium transition-all">
+              <p>
+                {isShowFullComment ? (
+                  review?.comment
+                ) : (
+                  <>
+                    {truncateText(review?.comment)}
+                    {isMoreView && (
+                      <button
+                        type="button"
+                        onClick={() => setIsShowText(true)}
+                        className="text-sm font-medium text-gray-500"
+                      >
+                        더보기
+                      </button>
+                    )}
+                  </>
+                )}
+              </p>
+            </div>
+
             <Link href={`/list-detail/${review?.Gathering?.id}`}>
               <p className="flex flex-row items-center gap-[0.375rem] text-xs font-medium">
                 <span>

--- a/constants/filter.ts
+++ b/constants/filter.ts
@@ -8,7 +8,7 @@ export const LOCATION_ITEMS = [
 
 export const SORT_ITEMS = {
   list: ["정렬", "최신순", "마감 임박", "참여 인원순"],
-  review: ["정렬", "오래된순", "평점 높은순", "참여 인원순"],
+  review: ["정렬", "오래된순", "평점 높은순", "평점 낮은순", "참여 인원순"],
 };
 
 export const sortMap: Record<string, string | undefined> = {

--- a/features/review/components/ClientReviewContainer.tsx
+++ b/features/review/components/ClientReviewContainer.tsx
@@ -2,7 +2,7 @@
 
 import { useInView } from "react-intersection-observer";
 import RatingContainer from "@features/review/components/RatingContainer";
-// import FilterBar from "@features/review/components/FilterBar";
+import FilterBar from "@features/review/components/FilterBar";
 import ReviewListwithImage from "@components/common/ReviewListWithImage";
 import Chip from "@components/common/Chip";
 import TabMenu from "@components/common/TabMenu";
@@ -20,11 +20,11 @@ function ClientReviewContainer() {
     isError,
     isFetchingNextPage,
     fetchNextPage,
-    handleChangeTabIndex,
-    handleChangeChipIndex,
-    // handleChangeLocation,
-    // handleChangeDate,
-    // handleChangeSort,
+    updateTabIndex,
+    updateChipIndex,
+    updateLocation,
+    updateDate,
+    updateSort,
   } = useReviewListViewModel();
 
   const { ref: loadMoreRef } = useInView({
@@ -46,13 +46,13 @@ function ClientReviewContainer() {
             hasIcon
             tabs={TABS}
             selectedIndex={filters.tabIndex}
-            onSelect={handleChangeTabIndex}
+            onSelect={updateTabIndex}
           />
           <div className="flex items-start gap-2">
             <Chip
               label="전체"
               selected={filters.chipIndex === 0}
-              onClick={() => handleChangeChipIndex(0)}
+              onClick={() => updateChipIndex(0)}
             />
             {filters.tabIndex === 0 &&
               chipOptions.map((chip, index) => (
@@ -60,7 +60,7 @@ function ClientReviewContainer() {
                   key={chip.label}
                   label={chip.label}
                   selected={filters.chipIndex === index + 1}
-                  onClick={() => handleChangeChipIndex(index + 1)}
+                  onClick={() => updateChipIndex(index + 1)}
                 />
               ))}
           </div>
@@ -71,11 +71,12 @@ function ClientReviewContainer() {
 
       <div className="flex h-full w-full flex-col items-start bg-white">
         <div className="sticky top-[174px] z-10 w-full md:top-[190px] lg:top-[194px]">
-          {/* <FilterBar
-            onLocationChange={handleChangeLocation}
-            onDateChange={handleChangeDate}
-            onSortChange={handleChangeSort}
-          /> */}
+          <FilterBar
+            filters={filters}
+            onLocationChange={updateLocation}
+            onDateChange={updateDate}
+            onSortChange={updateSort}
+          />
         </div>
 
         <div className="w-full px-4 pb-6 md:px-6">

--- a/features/review/components/FilterBar.tsx
+++ b/features/review/components/FilterBar.tsx
@@ -1,28 +1,41 @@
-// import DateFilter from "@components/common/DateFilter";
-// import LocationFilter from "@components/common/LocationFilter";
-// import SortFilter from "@components/common/SortFilter";
+import DateFilter from "@components/common/DateFilter";
+import LocationFilter from "@components/common/LocationFilter";
+import SortFilter from "@components/common/SortFilter";
+import { LOCATION_ITEMS, SORT_ITEMS } from "@constants/filter";
+import { ReviewListState } from "@customTypes/review";
 
-// interface FilterBarProps {
-//   onLocationChange?: (selectedLocation: string) => void;
-//   onDateChange?: (selectedDate: string | undefined) => void;
-//   onSortChange?: (selectedSort: string) => void;
-// }
+interface FilterBarProps {
+  filters: ReviewListState;
+  onLocationChange: (location: string | null) => void;
+  onDateChange: (date: string | null) => void;
+  onSortChange: (selected: string | null) => void;
+}
 
-// export default function FilterBar({
-//   onLocationChange,
-//   onDateChange,
-//   onSortChange,
-// }: FilterBarProps) {
-//   return (
-//     <div className="w-full border-t-2 border-gray-900 bg-white p-6">
-//       <div className="flex items-start justify-between self-stretch">
-//         <div className="flex items-start gap-2">
-//           <LocationFilter onLocationChange={onLocationChange} />
-//           <DateFilter onDateSelect={onDateChange} />
-//         </div>
-//         <SortFilter onSortChange={onSortChange} />
-//       </div>
-//       {/* // TODO 하단에 그라데이션 넣으면 좋을듯 */}
-//     </div>
-//   );
-// }
+export default function FilterBar({
+  filters,
+  onLocationChange,
+  onDateChange,
+  onSortChange,
+}: FilterBarProps) {
+  return (
+    <div className="w-full border-t-2 border-gray-900 bg-white p-6">
+      <div className="flex items-start justify-between self-stretch">
+        <div className="flex items-start gap-2">
+          {filters.tabIndex === 0 && (
+            <LocationFilter
+              selectedLocation={filters.location}
+              onLocationChange={onLocationChange}
+              locations={LOCATION_ITEMS}
+            />
+          )}
+          <DateFilter onDateSelect={onDateChange} loadDate={filters.date} />
+        </div>
+        <SortFilter
+          selectedSort={filters.sort}
+          onSortChange={onSortChange}
+          sortOptions={SORT_ITEMS.review}
+        />
+      </div>
+    </div>
+  );
+}

--- a/features/review/hooks/useReviewListViewModel.tsx
+++ b/features/review/hooks/useReviewListViewModel.tsx
@@ -5,15 +5,7 @@ import { GATHERING_TYPE, GatheringType } from "@constants/gatheringType";
 import { sortMap, ASC, DESC } from "@features/review/constants/review";
 import useGetReviewData from "@features/review/hooks/useGetReviewData";
 import useGetReviewScore from "@features/review/hooks/useGetReviewScore";
-
-interface ReviewListState {
-  tabIndex: number;
-  chipIndex: number;
-  type: GatheringType;
-  location: string;
-  date?: string;
-  sort: string;
-}
+import { ReviewListState } from "@customTypes/review";
 
 export default function useReviewListViewModel() {
   const [filters, setFilters] = useState<ReviewListState>({
@@ -58,24 +50,24 @@ export default function useReviewListViewModel() {
 
   const { data: scoreData } = useGetReviewScore({ type: filters.type });
 
-  const handleChangeTabIndex = (index: number) => {
+  const updateTabIndex = (index: number) => {
     setFilters((prev) => ({ ...prev, tabIndex: index, chipIndex: 0 }));
   };
 
-  const handleChangeChipIndex = (index: number) => {
+  const updateChipIndex = (index: number) => {
     setFilters((prev) => ({ ...prev, chipIndex: index }));
   };
 
-  const handleChangeLocation = (location: string) => {
-    setFilters((prev) => ({ ...prev, location }));
+  const updateLocation = (location: string | null) => {
+    setFilters((prev) => ({ ...prev, location: location ?? "지역전체" }));
   };
 
-  const handleChangeDate = (date?: string) => {
-    setFilters((prev) => ({ ...prev, date }));
+  const updateDate = (date?: string | null) => {
+    setFilters((prev) => ({ ...prev, date: date ?? undefined }));
   };
 
-  const handleChangeSort = (sort: string) => {
-    setFilters((prev) => ({ ...prev, sort }));
+  const updateSort = (sort: string | null) => {
+    setFilters((prev) => ({ ...prev, sort: sort ?? "정렬" }));
   };
 
   return {
@@ -87,10 +79,10 @@ export default function useReviewListViewModel() {
     isFetchingNextPage,
 
     fetchNextPage,
-    handleChangeTabIndex,
-    handleChangeChipIndex,
-    handleChangeLocation,
-    handleChangeDate,
-    handleChangeSort,
+    updateTabIndex,
+    updateChipIndex,
+    updateLocation,
+    updateDate,
+    updateSort,
   };
 }

--- a/features/review/hooks/useReviewListViewModel.tsx
+++ b/features/review/hooks/useReviewListViewModel.tsx
@@ -36,7 +36,10 @@ export default function useReviewListViewModel() {
     location: filters.location === "지역전체" ? undefined : filters.location,
     date: filters.date,
     sortBy: sortMap[filters.sort] || undefined,
-    sortOrder: filters.sort === "오래된순" ? ASC : DESC,
+    sortOrder:
+      filters.sort === "오래된순" || filters.sort === "평점 낮은순"
+        ? ASC
+        : DESC,
     limit: 10,
   };
 

--- a/types/review.d.ts
+++ b/types/review.d.ts
@@ -28,6 +28,15 @@ export interface ReviewListWithImageProps {
   hasUserInfo?: boolean;
 }
 
+export interface ReviewListState {
+  tabIndex: number;
+  chipIndex: number;
+  type: GatheringType;
+  location: string;
+  date?: string;
+  sort: string;
+}
+
 export interface Scores {
   teamId: number;
   // gatheringId: 0, 얘가 무슨 역할을 하는지 아직 모르겠음..

--- a/utils/truncateText.ts
+++ b/utils/truncateText.ts
@@ -1,0 +1,8 @@
+/* eslint-disable import/prefer-default-export */
+export const truncateText = (
+  text: string | undefined,
+  maxLength: number = 60,
+) => {
+  if (!text) return "";
+  return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용
- [x] 바뀐 필터(LocationFilter, DateFilter, SortFilter)에 맞춰서 리뷰페이지 필터링 적용
- [x]  리뷰페이지 정렬 필터 옵션에 평점 낮은순 추가
- [x]  리뷰 내용이 일정 글자수(60자로 했습니다)가 넘어가면 더보기 버튼 생성하도록 수정


### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/c535f483-dfe3-4460-b019-c7183c6773e4)

![image](https://github.com/user-attachments/assets/8df1ed55-41da-41a7-882c-b9106f70579a)
![image](https://github.com/user-attachments/assets/192756d7-808e-40fe-843c-7f33bb882686)

## 💬리뷰 요구사항(선택)

