### PR TITLE
♻️ 회원가입 완료 시 모달 닫기버튼 표시하지 않도록 UI개선

### DIFF
--- a/components/common/AlertModal.tsx
+++ b/components/common/AlertModal.tsx
@@ -18,7 +18,7 @@ export default function AlertModal({
   onConfirm,
 }: AlertModalProps) {
   const alignItems = hasTwoButton ? "items-start" : "items-end";
-  const visibility = text.includes("회원가입") ? "hidden" : "";
+  const visibility = text.includes("회원가입") ? "invisible" : "";
 
   if (!isOpen) return null;
 

--- a/components/common/AlertModal.tsx
+++ b/components/common/AlertModal.tsx
@@ -18,6 +18,7 @@ export default function AlertModal({
   onConfirm,
 }: AlertModalProps) {
   const alignItems = hasTwoButton ? "items-start" : "items-end";
+  const visibility = text.includes("회원가입") ? "hidden" : "";
 
   if (!isOpen) return null;
 
@@ -36,8 +37,10 @@ export default function AlertModal({
                   alt="close button"
                   width={24}
                   height={24}
+                  className={`${visibility}`}
                 />
               </button>
+
               <div className="w-[15.75rem] text-center text-base font-medium text-gray-900 md:w-[25.125rem]">
                 {text}
               </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용
- [x] 회원가입 완료 시에는 모달 닫기버튼 표시하지 않도록 UI개선
### 스크린샷 (선택)
회원가입 완료 시
![image](https://github.com/user-attachments/assets/817ca115-909e-4087-92cc-cc9e41d7ddf0)
기본
![image](https://github.com/user-attachments/assets/8f019f1e-2dea-47b2-ac1a-b98767cda5eb)

## 💬리뷰 요구사항(선택)

