### PR TITLE
♻️ 모임일자를 기본 날짜로 표기 후 작성일 추가

### DIFF
--- a/components/common/ReviewItemWithImage.tsx
+++ b/components/common/ReviewItemWithImage.tsx
@@ -74,24 +74,30 @@ export default function ReviewItemWithImage({
               </p>
             </Link>
           </div>
-          <div className="flex flex-row items-center gap-3">
-            {hasUserInfo && (
-              <p className="flex flex-row items-center gap-2">
-                <span className="relative size-6 overflow-hidden rounded-full">
-                  <Image
-                    alt="user-profile"
-                    fill
-                    src={review?.User?.image ?? DEFAULT_USER_IMAGE}
-                  />
-                </span>
-                <span className="text-xs font-medium">
-                  {review?.User?.name}
-                </span>
-                <span>|</span>
-              </p>
-            )}
-            <span className="text-xs font-medium text-gray-500">
-              {formatDate(review?.createdAt)}
+          <div className="flex w-full items-center justify-between">
+            <div className="flex flex-row items-center gap-3">
+              {hasUserInfo && (
+                <p className="flex flex-row items-center gap-2">
+                  <span className="relative size-6 overflow-hidden rounded-full">
+                    <Image
+                      alt="user-profile"
+                      fill
+                      src={review?.User?.image ?? DEFAULT_USER_IMAGE}
+                    />
+                  </span>
+                  <span className="text-xs font-medium">
+                    {review?.User?.name}
+                  </span>
+                  <span>|</span>
+                </p>
+              )}
+
+              <span className="text-xs font-medium text-gray-500">
+                {formatDate(review?.Gathering.dateTime)}
+              </span>
+            </div>
+            <span className="text-end text-xs font-medium text-gray-500">
+              작성일 {formatDate(review?.createdAt)}
             </span>
           </div>
         </div>

--- a/features/review/constants/review.ts
+++ b/features/review/constants/review.ts
@@ -8,9 +8,10 @@ export const chipOptions = [
 export const sortMap: Record<string, string> = {
   오래된순: "createdAt",
   "평점 높은순": "score",
+  "평점 낮은순": "score",
   "참여 인원순": "participantCount",
 };
 
-export const DESC: "asc" | "desc" | undefined = "desc";
+export const DESC = "desc" as const;
 
-export const ASC: "asc" | "desc" | undefined = "asc";
+export const ASC = "asc" as const;


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용
- [x] 모임 일자를 기본 날짜로 표기 후 작성일 추가
- [x] 평점 낮은순 필터링 시 sort mapping하는 부분이 빠져서 추가함

### 스크린샷 (선택)
![작성일](https://github.com/user-attachments/assets/7cfe45fd-e806-45ee-9e53-e70f10bcb893)
![작성일2](https://github.com/user-attachments/assets/ff8412cf-4eb1-4e34-8674-18827954e784)


## 💬리뷰 요구사항(선택)

추가한 부분이 제가 보기에는 나쁘지 않은것 같습니다..!!
아이디어 주신 민주님 감사해요ㅎㅎ
