### PR TITLE
🐛 상세페이지 참여하기 클릭 시 관련 쿼리 무효화 추가

### DIFF
--- a/features/list-detail/hooks/useClickHandlers.ts
+++ b/features/list-detail/hooks/useClickHandlers.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 
 interface UserStore {
   id: number | null;
@@ -43,6 +44,7 @@ export default function useClickHandlers({
   setModalConfig,
 }: UseClickHandlersProps) {
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const handleJoinClick = useCallback(() => {
     if (userData?.id) {
@@ -59,6 +61,7 @@ export default function useClickHandlers({
               onClose: () =>
                 setModalConfig((prev) => ({ ...prev, isOpen: false })),
             });
+            queryClient.invalidateQueries({ queryKey: ["gatheringsJoined"] });
           },
         });
       }


### PR DESCRIPTION

## #️⃣연관된 이슈

> 

## 📝작업 내용

> 기존에 상세페이지에서 참여하기를 눌러도 마이페이지에서 바로 조회가 안되고 새로고침을 해야 보이는 이슈가 있었습니다. 
> - 상세페이지 참여하기 클릭 시 마이페이지에서 바로 조회가 가능하도록 쿼리 무효화하는 로직을 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> @imsoohyeok 수혁님이 작성하신 훅 수정했는데 한번 확인해주시면 감사하겠습니다! 🙇‍♀️
