### PR TITLE
✨ 폰트 로딩 전략 FOUT에서 FOIT으로 변경

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
-import Head from "next/head";
 import "./globals.css";
 import Gnb from "@components/common/Gnb";
 import ReactQueryProvider from "@providers/ReactQueryProvider";
@@ -14,7 +13,7 @@ export const metadata: Metadata = {
 
 const pretendard = localFont({
   src: "../public/fonts/PretendardVariable.woff2",
-  display: "swap",
+  display: "block",
   variable: "--font-pretendard",
 });
 
@@ -24,30 +23,19 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <>
-      <Head>
-        <link
-          rel="preload"
-          href="/fonts/PretendardVariable.woff2"
-          as="font"
-          type="font/woff2"
-          crossOrigin="anonymous"
-        />
-      </Head>
-      <html lang="ko">
-        <body
-          className={`flex h-screen flex-col bg-white ${pretendard.variable} font-pretendard antialiased`}
-        >
-          <ReactQueryProvider>
-            <div className="fixed left-0 top-0 z-20 w-full">
-              <Gnb />
-            </div>
-            <div className="flex w-full flex-1 pt-[54px] md:pt-[60px]">
-              {children}
-            </div>
-          </ReactQueryProvider>
-        </body>
-      </html>
-    </>
+    <html lang="ko">
+      <body
+        className={`flex h-screen flex-col bg-white ${pretendard.variable} font-pretendard antialiased`}
+      >
+        <ReactQueryProvider>
+          <div className="fixed left-0 top-0 z-20 w-full">
+            <Gnb />
+          </div>
+          <div className="flex w-full flex-1 pt-[54px] md:pt-[60px]">
+            {children}
+          </div>
+        </ReactQueryProvider>
+      </body>
+    </html>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용
- [x] display: "swqp" -> display: "block"

### 스크린샷 (선택)
변경 전
![제목 없는 디자인 (3)](https://github.com/user-attachments/assets/1f0db0c6-647c-4b07-af98-ee93c058fa18)

변경 후
![제목 없는 디자인 (4)](https://github.com/user-attachments/assets/b318d109-3995-46a3-8f04-94dee6753544)

레이아웃 변경이 없는 일관된 디자인을 보여주기 위해 FOIT 전략을 채택했습니다.

## 💬리뷰 요구사항(선택)

