### PR TITLE
♻️ 리스트페이지 margin top 복구

### DIFF
--- a/app/(layout_dafault)/list/page.tsx
+++ b/app/(layout_dafault)/list/page.tsx
@@ -11,7 +11,7 @@ export default async function List() {
   return (
     <HydrationBoundary state={state}>
       <Suspense fallback={<div>로딩 중...</div>}>
-        <section className="mb-6 flex items-center justify-start gap-4 sm:mb-8">
+        <section className="mb-6 flex items-center justify-start gap-4 pt-6 sm:mb-8 sm:pt-8">
           <HeartImage className="w-18 h-18" />
           <div>
             <p className="text-sm font-medium">함께 할 사람이 없나요?</p>

--- a/features/list/components/ListContainer.tsx
+++ b/features/list/components/ListContainer.tsx
@@ -25,7 +25,7 @@ export default function ListContainer() {
   } = GatheringViewModel();
 
   return (
-    <div className="flex w-full flex-col pt-6 md:pt-8">
+    <div className="flex w-full flex-col">
       <section className="mb-[14px] flex flex-wrap items-center justify-between">
         <TabMenu
           hasIcon


### PR DESCRIPTION
## 📝작업 내용

<img width="824" alt="image" src="https://github.com/user-attachments/assets/9fbaa6dd-b353-4b9a-af4d-8e00ee09cbed" />

모임리스트 코드 리팩토링 시 제거된 margin top 추가하였습니다.