### PR TITLE
♻️ 예약 취소하기 버튼 문구 수정

### DIFF
--- a/features/mypage/components/MypageCard.test.tsx
+++ b/features/mypage/components/MypageCard.test.tsx
@@ -129,7 +129,7 @@ describe("MypageCard Component", () => {
     ).not.toBeInTheDocument();
   });
 
-  test("should call openModal with cancellation message when '예약 취소하기' button is clicked", () => {
+  test("should call openModal with cancellation message when '참여 취소하기' button is clicked", () => {
     const mockOpenModal = jest.fn();
     (
       useModalStore as jest.MockedFunction<typeof useModalStore>
@@ -143,7 +143,7 @@ describe("MypageCard Component", () => {
 
     render(<MypageCard gatheringData={pendingOnlineGatheringData} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /예약 취소하기/ }));
+    fireEvent.click(screen.getByRole("button", { name: /참여 취소하기/ }));
 
     expect(mockOpenModal).toHaveBeenCalledWith({
       text: "정말 모임 참여를 취소하시겠습니까?",
@@ -176,7 +176,7 @@ describe("MypageCard Component", () => {
 
     render(<MypageCard gatheringData={pendingOnlineGatheringData} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /예약 취소하기/ }));
+    fireEvent.click(screen.getByRole("button", { name: /참여 취소하기/ }));
 
     await waitFor(() =>
       expect(mockOpenModal).toHaveBeenCalledWith({
@@ -211,7 +211,7 @@ describe("MypageCard Component", () => {
 
     render(<MypageCard gatheringData={nonCancelableGatheringData} />);
 
-    const button = screen.getByRole("button", { name: "예약 취소하기" });
+    const button = screen.getByRole("button", { name: "참여 취소하기" });
 
     expect(button).toBeDisabled();
   });

--- a/features/mypage/components/MypageCard.tsx
+++ b/features/mypage/components/MypageCard.tsx
@@ -101,7 +101,7 @@ export default function MypageCard({
           {!isMadeByMe && (
             <Button
               text={
-                gatheringData.isCompleted ? "리뷰 작성하기" : "예약 취소하기"
+                gatheringData.isCompleted ? "리뷰 작성하기" : "참여 취소하기"
               }
               size="small"
               disabled={isRegistrationEnded && !gatheringData.isCompleted}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> - 마이페이지의 '예약 취소하기' 버튼 문구가 부자연스러운 것 같아 '참여 취소하기' 로 수정했습니다.

### 스크린샷 (선택)
- 수정 전
<img width="405" alt="스크린샷 2025-03-14 오전 11 31 50" src="https://github.com/user-attachments/assets/bebfbea4-4f47-4a5d-84f1-a6d3de10d824" />

- 수정 후
<img width="445" alt="스크린샷 2025-03-14 오전 11 31 30" src="https://github.com/user-attachments/assets/3462e85d-d3b6-492b-ab7b-a334024abf82" />


## 💬리뷰 요구사항(선택)

> 