### PR TITLE
✨ 모임리스트페이지 마감된 모임 처리 체크박스 추가

### DIFF
--- a/components/common/Chip.tsx
+++ b/components/common/Chip.tsx
@@ -11,7 +11,7 @@ export default function Chip({ label, selected = false, onClick }: ChipProps) {
       onClick={onClick}
       aria-pressed={selected}
       title={label}
-      className={`inline-flex items-center justify-center rounded-lg font-medium transition ${selected ? "border-black bg-gray-900 text-white" : "bg-gray-200 text-gray-900"} min-h-[2.25rem] min-w-[3.0625rem] px-3 py-2 text-sm md:px-4 md:py-[0.625rem]`}
+      className={`inline-flex items-center justify-center rounded-lg font-medium transition ${selected ? "border-black bg-gray-900 text-white" : "bg-gray-200 text-gray-900"} h-[2.25rem] min-w-[3.0625rem] px-3 py-2 text-sm md:px-4 md:py-[0.625rem]`}
     >
       {label}
     </button>

--- a/components/common/ChipFilterGroup.tsx
+++ b/components/common/ChipFilterGroup.tsx
@@ -9,7 +9,7 @@ export default function ChipFilterGroup({
   setTypeFilter,
 }: ChipFilterGroupProps) {
   return (
-    <>
+    <div className="flex justify-start gap-2">
       {subChips.map((chip) => (
         <Chip
           key={chip.value}
@@ -18,6 +18,6 @@ export default function ChipFilterGroup({
           onClick={() => setTypeFilter(chip.value)}
         />
       ))}
-    </>
+    </div>
   );
 }

--- a/components/common/ExpiredFilterCheckbox.tsx
+++ b/components/common/ExpiredFilterCheckbox.tsx
@@ -10,7 +10,7 @@ export default function ExpiredFilterCheckbox({
 }: ExpiredFilterCheckboxProps) {
   return (
     <div
-      className="mt-7 flex cursor-pointer items-center gap-1"
+      className="mt-1 flex cursor-pointer items-center gap-1"
       onClick={() => setShowExpired((prev) => !prev)}
       role="button"
       tabIndex={0}

--- a/components/common/ExpiredFilterCheckbox.tsx
+++ b/components/common/ExpiredFilterCheckbox.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { ExpiredFilterCheckboxProps } from "@customTypes/filters";
+import { IMAGES } from "@constants/gathering";
+import Image from "next/image";
+
+export default function ExpiredFilterCheckbox({
+  showExpired,
+  setShowExpired,
+}: ExpiredFilterCheckboxProps) {
+  return (
+    <div
+      className="mt-7 flex cursor-pointer items-center gap-1"
+      onClick={() => setShowExpired((prev) => !prev)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") setShowExpired((prev) => !prev);
+      }}
+    >
+      <Image
+        alt="checkbox"
+        src={showExpired ? IMAGES.CHECKBOX : IMAGES.DEFAULT_CHECKBOX}
+        width={24}
+        height={24}
+      />
+      <span className="text-sm font-medium">마감 포함</span>
+    </div>
+  );
+}

--- a/components/common/GatheringItem.tsx
+++ b/components/common/GatheringItem.tsx
@@ -27,6 +27,7 @@ export default function GatheringItem({ gathering }: GatheringItemProps) {
           <GatheringStatusBadge registrationEnd={gathering.registrationEnd} />
           <Image
             fill
+            sizes="100%"
             alt={gathering.name || "list-default"}
             src={gathering.image || IMAGES.DEFAULT_REVIEW}
           />
@@ -119,6 +120,7 @@ export default function GatheringItem({ gathering }: GatheringItemProps) {
                     src={IMAGES.ARROW_RIGHT}
                     width={18}
                     height={18}
+                    style={{ width: "auto", height: "auto" }}
                   />
                 </div>
               )}

--- a/components/common/GatheringList.tsx
+++ b/components/common/GatheringList.tsx
@@ -1,8 +1,12 @@
 import GatheringItem from "@components/common/GatheringItem";
 import { GatheringListProps } from "@customTypes/gathering";
 import { useHiddenGatheringStore } from "@stores/hiddenGatheringStore";
+import { isExpired } from "@utils/dateFormatter";
 
-export default function GatheringList({ gatherings }: GatheringListProps) {
+export default function GatheringList({
+  gatherings,
+  showExpired,
+}: GatheringListProps) {
   const hiddenExpiredIds = useHiddenGatheringStore(
     (state) => state.hiddenExpiredIds,
   );
@@ -18,7 +22,9 @@ export default function GatheringList({ gatherings }: GatheringListProps) {
 
   const filteredGatherings = gatherings.filter(
     (gathering) =>
-      gathering.canceledAt === null && !hiddenExpiredIds.includes(gathering.id),
+      gathering.canceledAt === null &&
+      !hiddenExpiredIds.includes(gathering.id) &&
+      (showExpired || !isExpired(gathering.registrationEnd)),
   );
 
   if (filteredGatherings.length === 0) {

--- a/constants/gathering.ts
+++ b/constants/gathering.ts
@@ -4,6 +4,7 @@ export const IMAGES = {
   HEART_ACTIVE: "/image/icon-save-large-active.svg",
   ARROW_RIGHT: "/image/arrow_right.svg",
   CHECKBOX: "/image/icon-checkbox-active.svg",
+  DEFAULT_CHECKBOX: "/image/icon-checkbox-default.svg",
   BYE: "/image/icon-bye-circle-large-discard.svg",
   WATCH: "/image/Group 33855.svg",
   PERSON: "/image/person.svg",

--- a/features/list/components/GatheringStatusBadge.tsx
+++ b/features/list/components/GatheringStatusBadge.tsx
@@ -14,7 +14,13 @@ export default function GatheringStatusBadge({
 
   return (
     <div className="absolute right-0 top-0 z-10 flex h-8 min-w-[100px] rounded-bl-xl bg-mint-600 p-2">
-      <Image src={IMAGES.WATCH} alt="WATCH" width={24} height={24} />
+      <Image
+        src={IMAGES.WATCH}
+        alt="WATCH"
+        width={24}
+        height={24}
+        style={{ width: "auto", height: "auto" }}
+      />
       <p className="text-xs font-medium text-white">
         {expired
           ? "마감된 모임"

--- a/features/list/components/ListContainer.tsx
+++ b/features/list/components/ListContainer.tsx
@@ -66,7 +66,7 @@ export default function ListContainer() {
         <GatheringList gatherings={gatherings} showExpired={showExpired} />
       </section>
       <div ref={loadMoreRef} className="bg-red-500 w-30 z-10 h-10 text-center">
-        {isFetchingNextPage ? "로딩 중..." : ""}
+        {isFetchingNextPage ? "" : ""}
       </div>
     </div>
   );

--- a/features/list/components/ListContainer.tsx
+++ b/features/list/components/ListContainer.tsx
@@ -7,9 +7,12 @@ import { GatheringViewModel } from "@features/list/hooks/GatheringViewModel";
 import CreateGatheringButton from "@features/list/components/CreateGatheringButton";
 import ChipFilterGroup from "@components/common/ChipFilterGroup";
 import FilterOptions from "@features/list/components/FilterOptions";
+import ExpiredFilterCheckbox from "@components/common/ExpiredFilterCheckbox";
 
 export default function ListContainer() {
   const {
+    showExpired,
+    setShowExpired,
     selectedTabIndex,
     setTabIndex,
     typeFilter,
@@ -24,6 +27,8 @@ export default function ListContainer() {
     isFetchingNextPage,
     loadMoreRef,
   } = GatheringViewModel();
+  console.log(filters);
+  console.log(sortBy);
 
   return (
     <div className="flex w-full flex-col">
@@ -36,14 +41,19 @@ export default function ListContainer() {
         />
         <CreateGatheringButton />
       </section>
-      <section className="flex justify-start gap-2">
+      <section className="flex justify-between">
         <ChipFilterGroup
           subChips={subChips}
           typeFilter={typeFilter}
           setTypeFilter={setTypeFilter}
         />
+        <ExpiredFilterCheckbox
+          showExpired={showExpired}
+          setShowExpired={setShowExpired}
+        />
       </section>
       <hr className="my-4 w-full border-t-2 border-gray-200" />
+
       <section className="mb-4 sm:mb-6">
         <FilterOptions
           selectedTabIndex={selectedTabIndex}
@@ -55,7 +65,7 @@ export default function ListContainer() {
         />
       </section>
       <section>
-        <GatheringList gatherings={gatherings} />
+        <GatheringList gatherings={gatherings} showExpired={showExpired} />
       </section>
       <div ref={loadMoreRef} className="bg-red-500 w-30 z-10 h-10 text-center">
         {isFetchingNextPage ? "로딩 중..." : ""}

--- a/features/list/components/ListContainer.tsx
+++ b/features/list/components/ListContainer.tsx
@@ -27,8 +27,6 @@ export default function ListContainer() {
     isFetchingNextPage,
     loadMoreRef,
   } = GatheringViewModel();
-  console.log(filters);
-  console.log(sortBy);
 
   return (
     <div className="flex w-full flex-col">

--- a/features/list/hooks/GatheringViewModel.ts
+++ b/features/list/hooks/GatheringViewModel.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { sortMap } from "@constants/filter";
 import { useQueryString } from "@hooks/useQueryString";
 import { useQueryTabIndex } from "@hooks/useQueryTabIndex";
@@ -10,6 +10,7 @@ import { Gathering } from "@customTypes/gathering";
 import { useFavoriteStore } from "@stores/favoriteStore";
 
 export function GatheringViewModel() {
+  const [showExpired, setShowExpired] = useState(false);
   const [selectedTabIndex, setTabIndex] = useQueryTabIndex();
   const [typeFilter, setTypeFilter] = useQueryString("type", "DALLAEMFIT");
   const [locationFilter, setLocationFilter] = useQueryString("location", null);
@@ -81,6 +82,8 @@ export function GatheringViewModel() {
   const { clearFavorites } = useFavoriteStore();
 
   return {
+    showExpired,
+    setShowExpired,
     selectedTabIndex,
     setTabIndex,
     typeFilter,

--- a/types/filters.ts
+++ b/types/filters.ts
@@ -18,3 +18,8 @@ export interface ChipFilterGroupProps {
   typeFilter: string | null;
   setTypeFilter: (value: string) => void;
 }
+
+export interface ExpiredFilterCheckboxProps {
+  showExpired: boolean;
+  setShowExpired: React.Dispatch<React.SetStateAction<boolean>>;
+}

--- a/types/gathering.d.ts
+++ b/types/gathering.d.ts
@@ -19,6 +19,7 @@ export interface GatheringItemProps {
 
 export interface GatheringListProps {
   gatherings: Gathering[];
+  showExpired?: boolean;
 }
 
 export interface GatheringParams {


### PR DESCRIPTION
## 📝작업 내용

모임리스트페이지 마감된 모임을 처리하는 체크박스 컴포넌트 제작 및 적용하였습니다.

기본상태
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/6073cd62-2865-45c8-b5ec-f866c9b633c8" />

마감 포함 보기 선택 시 
<img width="998" alt="image" src="https://github.com/user-attachments/assets/342c8715-1448-4c6a-a372-6d0762346ec1" />

1. 유저가 선택 시 마감된 모임을 볼 수 있도록 체크박스 컴포넌트제작하였습니다. (기본값 숨김)
2. 모임리스트 페이지에 마감체크박스 적용하였습니다.
3. 모임리스트 컴포넌트에 마감된 모임 필터링 시 hidden 기능 로직 추가하였습니다.
4. 이미지 비욜에 맞게 style 100으로 설정하였습니다.

