### PR TITLE
⚡️ 리뷰페이지 이미지 최적화

### DIFF
--- a/components/common/ReviewItem.tsx
+++ b/components/common/ReviewItem.tsx
@@ -12,20 +12,25 @@ export default function ReviewItem({ review }: ReviewItemProps) {
           <ReviewRating score={review?.score} />
           <p className="text-sm font-medium">{review?.comment}</p>
         </div>
-        <div className="flex flex-row items-center gap-3">
-          <p className="flex flex-row items-center gap-2">
-            <span className="relative size-6 overflow-hidden rounded-full">
-              <Image
-                alt="user-profile"
-                fill
-                src={review?.User?.image ?? DEFAULT_USER_IMAGE}
-              />
+        <div className="flex w-full items-center justify-between">
+          <div className="flex flex-row items-center gap-3">
+            <p className="flex flex-row items-center gap-2">
+              <span className="relative size-6 overflow-hidden rounded-full">
+                <Image
+                  alt="user-profile"
+                  fill
+                  src={review?.User?.image ?? DEFAULT_USER_IMAGE}
+                />
+              </span>
+              <span className="text-xs font-medium">{review?.User?.name}</span>
+              <span>|</span>
+            </p>
+            <span className="text-xs font-medium text-gray-500">
+              {formatDate(review?.Gathering.dateTime)}
             </span>
-            <span className="text-xs font-medium">{review?.User?.name}</span>
-            <span>|</span>
-          </p>
-          <span className="text-xs font-medium text-gray-500">
-            {formatDate(review?.createdAt)}
+          </div>
+          <span className="text-end text-xs font-medium text-gray-500">
+            작성일 {formatDate(review?.createdAt)}
           </span>
         </div>
       </div>

--- a/components/common/ReviewItemWithImage.tsx
+++ b/components/common/ReviewItemWithImage.tsx
@@ -34,6 +34,7 @@ export default function ReviewItemWithImage({
           alt="gathering-image"
           src={review?.Gathering?.image}
           className="shrink-0 rounded-3xl object-cover"
+          sizes="(max-width: 768px) 100vw, 17.5rem"
         />
       </div>
 
@@ -81,6 +82,7 @@ export default function ReviewItemWithImage({
                     <Image
                       alt="user-profile"
                       fill
+                      sizes="24px"
                       src={review?.User?.image ?? DEFAULT_USER_IMAGE}
                     />
                   </span>

--- a/components/common/ReviewItemWithImage.tsx
+++ b/components/common/ReviewItemWithImage.tsx
@@ -13,6 +13,7 @@ import { truncateText } from "@utils/truncateText";
 export default function ReviewItemWithImage({
   review,
   hasUserInfo,
+  priority,
 }: ReviewItemWithImageProps) {
   const [isMoreView, setIsMoreView] = useState(false);
   const [isShowFullComment, setIsShowText] = useState(false);
@@ -35,6 +36,7 @@ export default function ReviewItemWithImage({
           src={review?.Gathering?.image}
           className="shrink-0 rounded-3xl object-cover"
           sizes="(max-width: 768px) 100vw, 17.5rem"
+          priority={priority}
         />
       </div>
 

--- a/components/common/ReviewListWithImage.tsx
+++ b/components/common/ReviewListWithImage.tsx
@@ -8,11 +8,12 @@ export default function ReviewListwithImage({
   return (
     <ol className="flex flex-col items-start gap-6 self-stretch">
       {reviewData &&
-        reviewData.map((review) => (
+        reviewData.map((review, index) => (
           <ReviewItemWithImage
             key={review.id}
             review={review}
             hasUserInfo={hasUserInfo}
+            priority={index === 0}
           />
         ))}
     </ol>

--- a/types/review.d.ts
+++ b/types/review.d.ts
@@ -6,6 +6,7 @@ export interface ReviewItemProps {
 
 export interface ReviewItemWithImageProps extends ReviewItemProps {
   hasUserInfo?: boolean;
+  priority: boolean;
 }
 
 export interface Review {


### PR DESCRIPTION
## #️⃣연관된 이슈
## 📝작업 내용
- [x] 이미지 없는 리뷰컴포넌트(상세페이지, 마이페이지에서 사용)에도 작성일 추가함
- [x] 이미지 size 속성 추가
- [x] 리뷰리스트 첫번째 이미지에 priority 속성 적용

### 스크린샷 (선택)
- 작성일 추가
![image](https://github.com/user-attachments/assets/831efec2-cba5-409a-8ca1-d305791f3ff9)

- 이미지 최적화 적용 전
![리뷰페이지 size 속성 적용 전](https://github.com/user-attachments/assets/30a58d95-6a79-45fb-bba6-8701bafb56d3)

- 이미지 최적화 적용 후
![0316리뷰페이지이미지최적화](https://github.com/user-attachments/assets/978c4105-6377-4d66-905b-e3cdb22fbd16)

## 💬리뷰 요구사항(선택)
