### PR TITLE
🐛 필터바 위치 조정

### DIFF
--- a/features/review/components/ClientReviewContainer.tsx
+++ b/features/review/components/ClientReviewContainer.tsx
@@ -70,7 +70,7 @@ function ClientReviewContainer() {
       <RatingContainer scoreData={scoreData} />
 
       <div className="flex h-full w-full flex-col items-start bg-white">
-        <div className="sticky top-[174px] z-10 w-full md:top-[190px] lg:top-[194px]">
+        <div className="sticky top-[174px] z-10 w-full md:top-[187px] lg:top-[191px]">
           <FilterBar
             filters={filters}
             onLocationChange={updateLocation}


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용
- [x] filter bar 부분의 위치를 올려 뒷배경이 보이지 않도록 함
### 스크린샷 (선택)
수정 전
![localhost_3000_review(iPad Mini) (2)](https://github.com/user-attachments/assets/6a45eaa6-8261-42ed-8098-fb1bcfb707af)

수정 후
![localhost_3000_review(iPad Mini)](https://github.com/user-attachments/assets/d0af3c14-516f-4dd2-805f-0aaf5a792b99)


## 💬리뷰 요구사항(선택)
