### PR TITLE
♻️ 모임리스트, 리뷰페이지 지역,날짜 필터 위치 변경

### DIFF
--- a/components/common/DateFilter.tsx
+++ b/components/common/DateFilter.tsx
@@ -45,7 +45,7 @@ function DatePickerModal({
   return (
     <div
       ref={modalRef}
-      className="absolute left-0 z-50 mt-1 w-[340px] rounded-md border bg-white p-6 shadow-md"
+      className="w-[320px]rounded-md absolute left-0 z-50 mt-1 border bg-white p-6 shadow-md sm:w-[340px]"
     >
       <div className="flex flex-col items-center">
         <DatePicker

--- a/features/list/components/FilterOptions.tsx
+++ b/features/list/components/FilterOptions.tsx
@@ -17,6 +17,10 @@ export default function FilterOptions({
   return (
     <div className="flex justify-between">
       <div className="flex gap-2">
+        <DateFilter
+          onDateSelect={(date) => setDateFilter(date)}
+          loadDate={filters.date}
+        />
         {selectedTabIndex === 0 && (
           <LocationFilter
             selectedLocation={filters.location}
@@ -24,10 +28,6 @@ export default function FilterOptions({
             locations={LOCATION_ITEMS}
           />
         )}
-        <DateFilter
-          onDateSelect={(date) => setDateFilter(date)}
-          loadDate={filters.date}
-        />
       </div>
       <div>
         <SortFilter

--- a/features/review/components/FilterBar.tsx
+++ b/features/review/components/FilterBar.tsx
@@ -21,6 +21,7 @@ export default function FilterBar({
     <div className="w-full border-t-2 border-gray-900 bg-white p-6">
       <div className="flex items-start justify-between self-stretch">
         <div className="flex items-start gap-2">
+          <DateFilter onDateSelect={onDateChange} loadDate={filters.date} />
           {filters.tabIndex === 0 && (
             <LocationFilter
               selectedLocation={filters.location}
@@ -28,7 +29,6 @@ export default function FilterBar({
               locations={LOCATION_ITEMS}
             />
           )}
-          <DateFilter onDateSelect={onDateChange} loadDate={filters.date} />
         </div>
         <SortFilter
           selectedSort={filters.sort}


### PR DESCRIPTION
## 📝작업 내용

1. 모임리스트, 리뷰페이지 지역날짜 필터 위치 변경하였습니다.
2. 모바일 se 크기에 맞게 모바일버전 모달창 크기 추가

기존 구름링에 경우 온라인 모임으로 지역필터가 존재하지 않습니다.
<img width="195" alt="image" src="https://github.com/user-attachments/assets/545a30a4-009f-4890-92a4-4eafc6832bac" />

모바일에서 모달창이 범위를 넘어가는 부분을 날짜필터를 앞으로 배치해도 괜찮다고 느꼈습니다.

적용후 모임리스트페이지
<img width="195" alt="image" src="https://github.com/user-attachments/assets/8b5569bd-c064-4325-8766-0efdb80990b0" />
적용후 리뷰페이지
<img width="196" alt="image" src="https://github.com/user-attachments/assets/5dc27715-5709-40b2-8396-93efc8d05fff" />
