### PR TITLE
♻️ 상세페이지 수정사항 반영

### DIFF
--- a/features/list-detail/components/FloatingBar.tsx
+++ b/features/list-detail/components/FloatingBar.tsx
@@ -28,9 +28,7 @@ export default function FloatingBar({
 }: FloatingBarProps) {
   let buttonElement = null;
 
-  if (isFull) {
-    buttonElement = <Button text="참여하기" size="small" disabled />;
-  } else if (isJoined) {
+  if (isJoined) {
     buttonElement = isCancelling ? (
       <Button text="취소 중..." size="small" disabled />
     ) : (
@@ -41,6 +39,8 @@ export default function FloatingBar({
         variant="outlined"
       />
     );
+  } else if (isFull) {
+    buttonElement = <Button text="참여하기" size="small" disabled />;
   } else {
     buttonElement = isJoining ? (
       <Button text="참여 중..." size="small" disabled />

--- a/features/list-detail/components/FloatingBar.tsx
+++ b/features/list-detail/components/FloatingBar.tsx
@@ -10,6 +10,7 @@ interface FloatingBarProps {
   onDeleteJoined: () => void;
   isJoining: boolean;
   isCancelling: boolean;
+  isCancelDisabled?: boolean;
   onShare: () => void;
 }
 
@@ -22,6 +23,7 @@ export default function FloatingBar({
   onDeleteJoined,
   isJoining,
   isCancelling,
+  isCancelDisabled = false,
   onShare,
 }: FloatingBarProps) {
   let buttonElement = null;
@@ -88,6 +90,7 @@ export default function FloatingBar({
                   size="large"
                   variant="outlined"
                   onClick={onCancel}
+                  disabled={isCancelDisabled}
                 />
                 <Button
                   text="공유하기"

--- a/features/list-detail/components/ListDetailContent.tsx
+++ b/features/list-detail/components/ListDetailContent.tsx
@@ -84,6 +84,10 @@ export default function ListDetailContent({
     return null;
   }
 
+  const meetingTime = new Date(data.dateTime);
+  const now = new Date();
+  const isPastMeetingTime = now > meetingTime;
+
   const isCreator = userData.id === gathering.createdBy;
   const formattedDateTime = formatDateTime(data.dateTime);
   const { date: dateString, time: timeString } = formattedDateTime;
@@ -132,6 +136,7 @@ export default function ListDetailContent({
           isJoining={joinStatus === "pending"}
           isCancelling={cancelStatus === "pending"}
           onShare={handleShareClick}
+          isCancelDisabled={isCreator && isPastMeetingTime}
         />
       </div>
 

--- a/features/list-detail/components/ListDetailContent.tsx
+++ b/features/list-detail/components/ListDetailContent.tsx
@@ -92,15 +92,19 @@ export default function ListDetailContent({
     <>
       <div className="mx-auto flex max-w-screen-lg flex-col gap-8 pb-20">
         <div className="mt-6 flex flex-col items-center justify-center gap-8 md:flex-row lg:mt-10">
-          <div className="relative">
-            <GatheringStatusBadge registrationEnd={gathering.registrationEnd} />
+          <div className="relative h-[180px] w-[343px] overflow-hidden rounded-[24px] border-2 border-gray-200 md:h-[270px] lg:w-[468px]">
             <Image
               src={gathering.image}
               alt="모임 장소 이미지"
-              className="h-[180px] w-[343px] rounded-[24px] border-2 border-gray-200 object-cover md:h-[270px] lg:w-[468px]"
+              className="h-full w-full object-cover"
               width={468}
               height={270}
             />
+            <div className="absolute right-0 top-0">
+              <GatheringStatusBadge
+                registrationEnd={gathering.registrationEnd}
+              />
+            </div>
           </div>
           <ContainerInformation
             maxCount={gathering.capacity}

--- a/features/list-detail/components/ReviewSection.tsx
+++ b/features/list-detail/components/ReviewSection.tsx
@@ -68,19 +68,21 @@ export default function ReviewSection({
   };
 
   return (
-    <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center gap-6 border-t-2 border-gray-200 bg-white p-6">
-      <div className="flex flex-col items-start gap-4">
+    <div className="mx-auto flex w-full max-w-screen-lg flex-col gap-6 border-t-2 border-gray-200 bg-white p-6">
+      <div className="flex w-full flex-col items-start gap-4">
         <span className="text-lg font-semibold text-gray-900">
           이용자들은 이 프로그램을 이렇게 느꼈어요!
         </span>
-        <div className="flex flex-col items-start gap-4">{renderContent()}</div>
+        <div className="w-full">{renderContent()}</div>
       </div>
       {computedTotalPages > 0 && (
-        <Pagination
-          currentPage={currentPage}
-          totalPages={computedTotalPages}
-          onPageChange={handlePageChange}
-        />
+        <div className="flex w-full justify-center">
+          <Pagination
+            currentPage={currentPage}
+            totalPages={computedTotalPages}
+            onPageChange={handlePageChange}
+          />
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## 📝작업 내용
간단한 css 수정 및 페이지 업데이트 했습니다.

- [x] 이미지에 모임 시간 뱃지 스타일 벗어나지 않게 수정
- [x] 리뷰 텍스트 길이에 따라 너비 차지 -> 무조건 좌우로 꽉 차게 수정
- [x] 모임 날짜가 지났을 경우, 주최자 페이지의 취소하기 버튼도 비활성화
- [x] 로그인한 사용자 포함하여 모임 인원이 꽉 찼을 경우, 해당 페이지 방문 시 비활성화된 참여하기 버튼 -> 참여 취소하기 버튼 보이도록 수정


### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/67bf056d-5c7a-4756-aadd-79a4b1dd3593)
![image](https://github.com/user-attachments/assets/769138cb-9861-4005-982f-3e8da7c56025)


## 💬리뷰 요구사항(선택)
