### PR TITLE
⚡️ 랜딩페이지 성능 개선

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,16 +10,13 @@ import FooterSection from "@features/landing/components/FooterSection";
 export default function Landing() {
   return (
     <div className="relative w-full bg-gray-50">
-      <AnimatedSection>
-        <LandingHero />
-      </AnimatedSection>
+      <LandingHero />
 
       <AnimatedSection>
         <FeatureSection />
       </AnimatedSection>
-      {/* <AnimatedSection> relative top-[60px] flex-1 */}
 
-      <div className="">
+      <div>
         <ServiceShowcaseSection />
       </div>
 

--- a/features/auth/components/AuthPageContainer.tsx
+++ b/features/auth/components/AuthPageContainer.tsx
@@ -56,6 +56,7 @@ function WelcomeTextWithImage() {
         width={0}
         height={0}
         className="mb-2 h-auto w-[18.125rem] md:w-96"
+        priority
       />
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용
- [x] 성능 개선 위해 랜딩히어로 섹션 fade-in 애니메이션 제거
- [x] auth페이지 이미지에 priorty 속성 부여 

### 스크린샷 (선택)
- fade-in 제거 전
![0317랜딩페이드인 제거전2](https://github.com/user-attachments/assets/862613a5-8095-4606-9ae3-5497f987230a)

- fade-in 제거 후
![0317랜딩페이드인 제거후-빌드2](https://github.com/user-attachments/assets/352f58e4-818d-42d1-b23c-a294eabfaf6b)

## 💬리뷰 요구사항(선택)
새롭게 알게 된 사실인데 LCP 후보에 fade-in 애니메이션이 적용되는게 성능에 치명적이라고 합니다... 
- 관련 자료
https://ui.toast.com/posts/ko_20220426#fade-in-%ED%95%98%EC%A7%80-%EC%95%8A%EA%B8%B0