### PR TITLE
♻️  유즈파람스 useState ->useSearchParams 관리 코드 변경

### DIFF
--- a/features/list/hooks/GatheringViewModel.ts
+++ b/features/list/hooks/GatheringViewModel.ts
@@ -30,11 +30,6 @@ export function GatheringViewModel() {
     [selectedTabIndex],
   );
 
-  useEffect(() => {
-    const newType = selectedTabIndex === 0 ? "DALLAEMFIT" : "WORKATION";
-    setTypeFilter(newType);
-  }, [selectedTabIndex]);
-
   const filters = useMemo(
     () => ({
       type: typeFilter,
@@ -43,14 +38,7 @@ export function GatheringViewModel() {
       sortBy: sortBy ? (sortMap[sortBy] ?? null) : null,
       sortOrder,
     }),
-    [
-      selectedTabIndex,
-      typeFilter,
-      locationFilter,
-      dateFilter,
-      sortBy,
-      sortOrder,
-    ],
+    [typeFilter, locationFilter, dateFilter, sortBy, sortOrder],
   );
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, error } =

--- a/hooks/useQueryString.ts
+++ b/hooks/useQueryString.ts
@@ -1,13 +1,17 @@
-import { useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
 
 export const useQueryString = (
   key: string,
   defaultValue: string | null = null,
 ): [string | null, (value: string | null) => void] => {
   const searchParams = useSearchParams();
-  const [search, setSearch] = useState<string | null>(
-    searchParams.get(key) ?? defaultValue,
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const search = useMemo(
+    () => searchParams.get(key) ?? defaultValue,
+    [searchParams, key],
   );
 
   const setValue = (value: string | null) => {
@@ -19,8 +23,9 @@ export const useQueryString = (
       newParams.set(key, value);
     }
 
-    setSearch(value ?? null);
-    window.history.replaceState(null, "", `?${newParams.toString()}`);
+    const newUrl = `${pathname}?${newParams.toString()}`;
+
+    router.replace(newUrl);
   };
 
   return [search, setValue];

--- a/hooks/useQueryTabIndex.ts
+++ b/hooks/useQueryTabIndex.ts
@@ -1,18 +1,15 @@
-import { useState, useCallback } from "react";
+import { useCallback } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 
 export const useQueryTabIndex = (): [number, (index: number) => void] => {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const [tabIndex, setTabIndexState] = useState(
-    Number(searchParams.get("tab") || 0),
-  );
+
+  const tabIndex = Number(searchParams.get("tab") || 0);
 
   const setTabIndex = useCallback(
     (index: number) => {
-      setTabIndexState(index);
-
       const newParams = new URLSearchParams(searchParams.toString());
       newParams.set("tab", String(index));
       newParams.set("type", index === 1 ? "WORKATION" : "DALLAEMFIT");


### PR DESCRIPTION
## 📝작업 내용

<img width="336" alt="image" src="https://github.com/user-attachments/assets/8b61b1ae-b977-4b9d-897e-d58095b93ca3" />
<img width="335" alt="image" src="https://github.com/user-attachments/assets/7c3a5725-fd76-4f67-8ec5-fe04bdbad560" />

새로고침 시 뒤로가기 시 필터가 잘 유지되나 tabindex를 통해서 내용을 수정하는 경우 필터가 바로 적용되지 않는 문제 발생

문제 원인
초기값은 유즈파람스로 잘 변경되었으나 이후에 값들 state로 관리되기 때문에 수정로직 필요

해결 방법
next의 useSearchParams는 상태관리 까지 자동업데이트 되는 기능이 있어 useSearchParams 관리하는 코드로 수정