### PR TITLE
🎨 Gnb 영역 z 인덱스 수정

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
         className={`flex h-screen flex-col bg-white ${pretendard.variable} font-pretendard antialiased`}
       >
         <ReactQueryProvider>
-          <div className="fixed left-0 top-0 z-20 w-full">
+          <div className="fixed left-0 top-0 z-50 w-full">
             <Gnb />
           </div>
           <div className="flex w-full flex-1 pt-[54px] md:pt-[60px]">


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> - Gnb와 마이페이지 헤딩이 겹치는 이슈가 있어서 Gnb 영역의 z 인덱스 수정했습니다.

### 스크린샷 (선택)
- 수정 전
<img width="456" alt="스크린샷 2025-03-17 오후 11 51 53" src="https://github.com/user-attachments/assets/2f131bd5-d2d7-40b6-b477-fd47cdfd18a0" />

- 수정 후
<img width="455" alt="스크린샷 2025-03-17 오후 11 52 12" src="https://github.com/user-attachments/assets/c8570a80-1ce1-4962-a8d4-b893adf25f50" />


## 💬리뷰 요구사항(선택)

>
